### PR TITLE
fix: improve prompts for create and list applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,17 +153,17 @@ pnpm run dev
 ```
 Once the server is running, you can utilize the MCP server within Visual Studio Code or other MCP client.
 
-## Upgrading ArgoCD Types
+### Upgrading ArgoCD Types
 
 To update the TypeScript type definitions based on the latest Argo CD API specification:
 
-1.  Download the `swagger.json` file from the [ArgoCD release page](https://github.com/argoproj/argo-cd/releases), for example here is the [swagger.json link](https://github.com/argoproj/argo-cd/blob/v2.14.11/assets/swagger.json) for ArgoCD v2.14.11.
+1. Download the `swagger.json` file from the [ArgoCD release page](https://github.com/argoproj/argo-cd/releases), for example here is the [swagger.json link](https://github.com/argoproj/argo-cd/blob/v2.14.11/assets/swagger.json) for ArgoCD v2.14.11.
 
-2.  Place the downloaded `swagger.json` file in the root directory of the `argocd-mcp` project.
+2. Place the downloaded `swagger.json` file in the root directory of the `argocd-mcp` project.
 
-3.  Generate the TypeScript types from the Swagger definition by running the following command. This will create or overwrite the `src/types/argocd.d.ts` file:
+3. Generate the TypeScript types from the Swagger definition by running the following command. This will create or overwrite the `src/types/argocd.d.ts` file:
     ```bash
     pnpm run generate-types
     ```
 
-4.  Update the `src/types/argocd-types.ts` file to export the required types from the newly generated `src/types/argocd.d.ts`. This step often requires manual review to ensure only necessary types are exposed.
+4. Update the `src/types/argocd-types.ts` file to export the required types from the newly generated `src/types/argocd.d.ts`. This step often requires manual review to ensure only necessary types are exposed.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -29,7 +29,12 @@ export class Server extends McpServer {
       'list_applications',
       'list_applications returns list of applications',
       {
-        search: z.string().nullish().describe('Search applications by name, optional')
+        search: z
+          .string()
+          .nullish()
+          .describe(
+            'Search applications by name. This is a partial match on the application name and does not support glob patterns (e.g. "*"). Optional.'
+          )
       },
       async ({ search }) =>
         await this.argocdClient.listApplications({ search: search ?? undefined })

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -31,7 +31,7 @@ export class Server extends McpServer {
       {
         search: z
           .string()
-          .nullish()
+          .optional()
           .describe(
             'Search applications by name. This is a partial match on the application name and does not support glob patterns (e.g. "*"). Optional.'
           )

--- a/src/shared/models/schema.ts
+++ b/src/shared/models/schema.ts
@@ -52,8 +52,7 @@ export const ApplicationSchema = z.object({
     })
       .refine(
         data =>
-          (data.server === undefined && data.name !== undefined) ||
-          (data.server !== undefined && data.name === undefined),
+          (!data.server && !!data.name) || (!!data.server && !data.name),
         {
           message: "Only one of server or name must be specified in destination"
         }

--- a/src/shared/models/schema.ts
+++ b/src/shared/models/schema.ts
@@ -46,9 +46,21 @@ export const ApplicationSchema = z.object({
         })
     }),
     destination: z.object({
-      server: z.string(),
-      namespace: z.string(),
+      server: z.string().optional(),
+      namespace: z.string().optional(),
       name: z.string().optional()
     })
+      .refine(
+        data =>
+          (data.server === undefined && data.name !== undefined) ||
+          (data.server !== undefined && data.name === undefined),
+        {
+          message: "Only one of server or name must be specified in destination"
+        }
+      )
+      .describe(
+        `The destination of the application.
+         Only one of server or name must be specified.`
+      )
   })
 });


### PR DESCRIPTION
Fixes #27 by explicitly mentioning the `search` parameter doesn't support glob expression in the prompt
Fixes #29 by making server and name optional and adding validation in zod