### PR TITLE
chore: add npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     types:
       - published
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -29,4 +33,4 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
           VERSION=${GITHUB_REF#refs/tags/v}
           npm version $VERSION --no-git-tag-version
-          npm publish --access public
+          npm publish --provenance --access public


### PR DESCRIPTION
Add npm provenance to the release workflow to avoid supply chain attack.