### PR TITLE
feat: add getResource tool to retrieve live resource manifest

### DIFF
--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -6,7 +6,8 @@ import {
   V1EventList,
   V1alpha1ResourceAction,
   V1alpha1ResourceDiff,
-  V1alpha1ResourceResult
+  V1alpha1ResourceResult,
+  V1alpha1ApplicationResourceResult
 } from '../types/argocd-types.js';
 import { HttpClient } from './http.js';
 
@@ -236,6 +237,25 @@ export class ArgoCDClient {
       `/api/v1/applications/${applicationName}/events`
     );
     return body;
+  }
+
+  public async getResource(
+    applicationName: string,
+    applicationNamespace: string,
+    resourceRef: V1alpha1ResourceResult
+  ) {
+    const { body } = await this.client.get<V1alpha1ApplicationResourceResult>(
+      `/api/v1/applications/${applicationName}/resource`,
+      {
+        appNamespace: applicationNamespace,
+        namespace: resourceRef.namespace,
+        resourceName: resourceRef.name,
+        group: resourceRef.group,
+        kind: resourceRef.kind,
+        version: resourceRef.version
+      }
+    );
+    return body.manifest;
   }
 
   public async getResourceEvents(

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -165,6 +165,17 @@ export class Server extends McpServer {
         )
     );
     this.addJsonOutputTool(
+      'get_resource',
+      'get_resource returns manifest of a kubernetes resources that belongs to an application',
+      {
+        applicationName: z.string(),
+        applicationNamespace: ApplicationNamespaceSchema,
+        resourceRef: ResourceRefSchema
+      },
+      async ({ applicationName, applicationNamespace, resourceRef }) =>
+        await this.argocdClient.getResource(applicationName, applicationNamespace, resourceRef)
+    );
+    this.addJsonOutputTool(
       'get_resource_actions',
       'get_resource_actions returns actions for a resource that is managed by an application',
       {

--- a/src/types/argocd-types.ts
+++ b/src/types/argocd-types.ts
@@ -10,3 +10,4 @@ export type V1EventList = ArgoCD.V1EventList;
 export type V1alpha1ResourceAction = ArgoCD.V1alpha1ResourceAction;
 export type V1alpha1ResourceDiff = ArgoCD.V1alpha1ResourceDiff;
 export type V1alpha1ResourceResult = ArgoCD.V1alpha1ResourceResult;
+export type V1alpha1ApplicationResourceResult = ArgoCD.ApplicationApplicationResourceResponse;


### PR DESCRIPTION
Closes https://github.com/argoproj-labs/mcp-for-argocd/issues/63

PR adds `getResource` tool that allows retrieving live resource manifest .