### PR TITLE
chore: on release publish image with tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,10 @@ name: Create and publish a Docker image
 
 on:
   push:
+    branches:
+      - main
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -44,6 +48,10 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+            type=ref,event=tag
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -57,5 +65,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      


### PR DESCRIPTION
PR Improves docker image workflow to publish image with the proper image tag when release is created. 
Sample run: https://github.com/alexmt/mcp-for-argocd/actions/runs/18733250848/job/53434722963