### PR TITLE
fix: add build step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Lint
         run:
           pnpm run lint
+      - name: Build
+        run:
+          pnpm run build
       - name: Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Closes https://github.com/argoproj-labs/mcp-for-argocd/issues/69

PR adds missing build step to release workflow