### PR TITLE
feat: add cluster management tool to list registered clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ const urlForGithub = `https://insiders.vscode.dev/redirect?url=${encodeURICompon
 
 The server provides the following ArgoCD management tools:
 
+### Cluster Management
+- `list_clusters`: List all clusters registered with ArgoCD
+
 ### Application Management
 - `list_applications`: List and filter all applications
 - `get_application`: Get detailed information about a specific application

--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -7,7 +7,8 @@ import {
   V1alpha1ResourceAction,
   V1alpha1ResourceDiff,
   V1alpha1ResourceResult,
-  V1alpha1ApplicationResourceResult
+  V1alpha1ApplicationResourceResult,
+  V1alpha1ClusterList
 } from '../types/argocd-types.js';
 import { HttpClient } from './http.js';
 
@@ -63,6 +64,19 @@ export class ArgoCDClient {
         hasMore: end < strippedItems.length
       }
     };
+  }
+
+  public async listClusters(params?: { server?: string; name?: string }) {
+    const queryParams: Record<string, string> = {};
+    if (params?.server) queryParams.server = params.server;
+    if (params?.name) queryParams.name = params.name;
+
+    const { body } = await this.client.get<V1alpha1ClusterList>(
+      `/api/v1/clusters`,
+      Object.keys(queryParams).length > 0 ? queryParams : undefined
+    );
+
+    return body;
   }
 
   public async getApplication(applicationName: string, appNamespace?: string) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -66,6 +66,25 @@ export class Server extends McpServer {
         })
     );
     this.addJsonOutputTool(
+      'list_clusters',
+      'list_clusters returns list of clusters registered with ArgoCD',
+      {
+        server: z
+          .string()
+          .optional()
+          .describe('Filter clusters by server URL. Optional.'),
+        name: z
+          .string()
+          .optional()
+          .describe('Filter clusters by name. Optional.')
+      },
+      async ({ server, name }) =>
+        await this.argocdClient.listClusters({
+          server: server ?? undefined,
+          name: name ?? undefined
+        })
+    );
+    this.addJsonOutputTool(
       'get_application',
       'get_application returns application by application name. Optionally specify the application namespace to get applications from non-default namespaces.',
       {

--- a/src/types/argocd-types.ts
+++ b/src/types/argocd-types.ts
@@ -11,3 +11,5 @@ export type V1alpha1ResourceAction = ArgoCD.V1alpha1ResourceAction;
 export type V1alpha1ResourceDiff = ArgoCD.V1alpha1ResourceDiff;
 export type V1alpha1ResourceResult = ArgoCD.V1alpha1ResourceResult;
 export type V1alpha1ApplicationResourceResult = ArgoCD.ApplicationApplicationResourceResponse;
+export type V1alpha1Cluster = ArgoCD.V1alpha1Cluster;
+export type V1alpha1ClusterList = ArgoCD.V1alpha1ClusterList;


### PR DESCRIPTION
Hi I saw a nice presentation in ArgoCon ATL today and was inspired to add another command for listing clusters in order to understand metadata we use with our ApplicationSets. We use cluster generators + labels and annotations to select deployment targets.

Thanks for the cool project!