### PR TITLE
feat: Run the container as non root for security reasons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ COPY --from=prod-deps /app/node_modules /app/node_modules
 COPY --from=build /app/dist /app/dist
 EXPOSE 3000
 CMD [ "node", "dist/index.js", "http" ]
+USER 1000


### PR DESCRIPTION
Changed the built image to run as node user by default. This is a best practice for software containers. This also makes it easier to run on Kubernetes with PSA restricted.