### PR TITLE
fix(http): preserve subpath in ARGOCD_BASE_URL

### DIFF
--- a/src/argocd/http.ts
+++ b/src/argocd/http.ts
@@ -87,7 +87,15 @@ export class HttpClient {
     if (url.startsWith('http://') || url.startsWith('https://')) {
       return new URL(url);
     }
-    return new URL(url, this.baseUrl);
+    // Preserve any subpath in baseUrl (e.g. https://host/argocd). JavaScript's
+    // URL constructor strips the base path when the input is absolute:
+    //   new URL('/api/v1/x', 'https://host/argocd').href === 'https://host/api/v1/x'
+    // which routes requests past the ingress mount-point for any ArgoCD
+    // installed behind a subpath. Make the input relative and ensure the
+    // base ends with a slash so the subpath is treated as a real prefix.
+    const base = this.baseUrl.endsWith('/') ? this.baseUrl : this.baseUrl + '/';
+    const rel = url.startsWith('/') ? url.slice(1) : url;
+    return new URL(rel, base);
   }
 
   async get<R>(url: string, params?: SearchParams): Promise<HttpResponse<R>> {


### PR DESCRIPTION
## Summary

`ARGOCD_BASE_URL` containing a subpath (e.g. `https://host/argocd`) is silently stripped from every outgoing request URL, so any ArgoCD behind an ingress at a subpath returns HTML instead of JSON and the MCP transport fails with `Unexpected token '<', \"<html>...\" is not valid JSON`.

## Root cause

`HttpClient.absUrl()` builds request URLs with:

```ts
return new URL(url, this.baseUrl);
```

where `url` is always an absolute path like `'/api/v1/applications'`. JavaScript's `URL` constructor [§5.3 of RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-5.3) replaces the entire path of the base when the input is absolute:

```js
new URL('/api/v1/applications', 'https://host/argocd').href
// => 'https://host/api/v1/applications'   ← /argocd is stripped
```

A trailing slash on the base doesn't help, because the input is absolute:

```js
new URL('/api/v1/applications', 'https://host/argocd/').href
// => 'https://host/api/v1/applications'   ← still strips /argocd
```

## Fix

Make the input *relative* and ensure the base ends with a slash so the subpath is treated as a real prefix:

```ts
const base = this.baseUrl.endsWith('/') ? this.baseUrl : this.baseUrl + '/';
const rel = url.startsWith('/') ? url.slice(1) : url;
return new URL(rel, base);
```

After this change:

| `baseUrl` | result |
|---|---|
| `https://host/argocd`  | `https://host/argocd/api/v1/applications` ✓ |
| `https://host/argocd/` | `https://host/argocd/api/v1/applications` ✓ |
| `https://host`         | `https://host/api/v1/applications` ✓ (unchanged) |
| `https://host/`        | `https://host/api/v1/applications` ✓ (unchanged) |

Users without a subpath are unaffected.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Repro confirmed with `argocd-mcp@0.7.0` against ArgoCD v3.1.9 behind APISIX at `/argocd`: pre-fix → `Unexpected token '<'` on every tool call; post-fix → real JSON responses for `list_applications`, `get_application`, `get_application_resource_tree`, `get_application_workload_logs`.
- [x] Verified the unaffected case (`https://host` with no subpath) still constructs `https://host/api/v1/...` correctly.

## Affected users

Anyone running ArgoCD behind an ingress that mounts it at a subpath — common when ArgoCD shares a hostname with other internal tools (e.g. `*.tools.example.com/argocd`). The current behavior surfaces as a generic JSON parse error with no upstream-URL information, so the root cause is hard to find without code-reading.