### PR TITLE
feat: add recent-activity filter to list_applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The server provides the following ArgoCD management tools:
 - `list_clusters`: List all clusters registered with ArgoCD
 
 ### Application Management
-- `list_applications`: List and filter all applications
+- `list_applications`: List and filter applications; optional `changedWithinMinutes` limits results to apps with recent sync/deploy activity
 - `get_application`: Get detailed information about a specific application
 - `create_application`: Create a new application
 - `update_application`: Update an existing application

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "pino": "^9.6.0",
         "yargs": "^17.7.2",
-        "zod": "^3.24.3"
+        "zod": "^3.25.0"
       },
       "bin": {
         "argocd-mcp": "dist/index.js"
@@ -730,9 +730,10 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",

--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -13,6 +13,8 @@ import {
 import { HttpClient } from './http.js';
 
 export class ArgoCDClient {
+  private static readonly TERMINAL_PHASES = new Set(['Succeeded', 'Failed', 'Error']);
+
   private baseUrl: string;
   private apiToken: string;
   private client: HttpClient;
@@ -23,32 +25,133 @@ export class ArgoCDClient {
     this.client = new HttpClient(this.baseUrl, this.apiToken);
   }
 
-  public async listApplications(params?: { search?: string; limit?: number; offset?: number }) {
+  private async fetchApplicationList(search?: string) {
     const { body } = await this.client.get<V1alpha1ApplicationList>(
       `/api/v1/applications`,
-      params?.search ? { search: params.search } : undefined
+      search ? { search } : undefined
     );
+    return body;
+  }
+
+  private stripApplicationFields(app: V1alpha1Application) {
+    return {
+      metadata: {
+        name: app.metadata?.name,
+        namespace: app.metadata?.namespace,
+        labels: app.metadata?.labels,
+        creationTimestamp: app.metadata?.creationTimestamp
+      },
+      spec: {
+        project: app.spec?.project,
+        source: app.spec?.source,
+        destination: app.spec?.destination
+      },
+      status: {
+        sync: app.status?.sync,
+        health: app.status?.health,
+        summary: app.status?.summary
+      }
+    };
+  }
+
+  private parseTimestamp(value?: string) {
+    if (!value) {
+      return null;
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+
+    return parsed;
+  }
+
+  private getLastSyncAt(app: V1alpha1Application) {
+    const candidates: Date[] = [];
+
+    const operationState = app.status?.operationState;
+    const operationFinishedAt = this.parseTimestamp(operationState?.finishedAt);
+    if (operationFinishedAt) {
+      candidates.push(operationFinishedAt);
+    }
+
+    if (operationState?.phase && !ArgoCDClient.TERMINAL_PHASES.has(operationState.phase)) {
+      const operationStartedAt = this.parseTimestamp(operationState?.startedAt);
+      if (operationStartedAt) {
+        candidates.push(operationStartedAt);
+      }
+    }
+
+    for (const historyItem of app.status?.history ?? []) {
+      const deployedAt = this.parseTimestamp(historyItem.deployedAt);
+      if (deployedAt) {
+        candidates.push(deployedAt);
+      }
+
+      const deployStartedAt = this.parseTimestamp(historyItem.deployStartedAt);
+      if (deployStartedAt) {
+        candidates.push(deployStartedAt);
+      }
+    }
+
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    return candidates.reduce((latest, current) =>
+      current.getTime() > latest.getTime() ? current : latest
+    );
+  }
+
+  public async listApplications(params?: {
+    search?: string;
+    limit?: number;
+    offset?: number;
+    changedWithinMinutes?: number;
+  }) {
+    const body = await this.fetchApplicationList(params?.search);
+
+    if (params?.changedWithinMinutes !== undefined) {
+      const cutoffDate = new Date(Date.now() - params.changedWithinMinutes * 60 * 1000);
+
+      const filteredItems =
+        body.items
+          ?.map((app) => {
+            const lastSyncAt = this.getLastSyncAt(app);
+            if (!lastSyncAt || lastSyncAt.getTime() < cutoffDate.getTime()) {
+              return null;
+            }
+
+            return {
+              ...this.stripApplicationFields(app),
+              lastSyncAt: lastSyncAt.toISOString()
+            };
+          })
+          .filter((app): app is NonNullable<typeof app> => app !== null)
+          .sort(
+            (a, b) => new Date(b.lastSyncAt).getTime() - new Date(a.lastSyncAt).getTime()
+          ) ?? [];
+
+      const start = params.offset ?? 0;
+      const end = params.limit ? start + params.limit : filteredItems.length;
+      const items = filteredItems.slice(start, end);
+
+      return {
+        items,
+        metadata: {
+          resourceVersion: body.metadata?.resourceVersion,
+          changedWithinMinutes: params.changedWithinMinutes,
+          cutoffTime: cutoffDate.toISOString(),
+          totalItems: filteredItems.length,
+          returnedItems: items.length,
+          hasMore: end < filteredItems.length
+        }
+      };
+    }
 
     // Strip heavy fields to reduce token usage
-    const strippedItems =
-      body.items?.map((app) => ({
-        metadata: {
-          name: app.metadata?.name,
-          namespace: app.metadata?.namespace,
-          labels: app.metadata?.labels,
-          creationTimestamp: app.metadata?.creationTimestamp
-        },
-        spec: {
-          project: app.spec?.project,
-          source: app.spec?.source,
-          destination: app.spec?.destination
-        },
-        status: {
-          sync: app.status?.sync,
-          health: app.status?.health,
-          summary: app.status?.summary
-        }
-      })) ?? [];
+    const strippedItems = body.items?.map((app) => this.stripApplicationFields(app)) ?? [];
 
     // Apply pagination
     const start = params?.offset ?? 0;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -33,13 +33,21 @@ export class Server extends McpServer {
     // Always register read/query tools
     this.addJsonOutputTool(
       'list_applications',
-      'list_applications returns list of applications',
+      'list_applications returns a list of applications. When changedWithinMinutes is set, returns only applications with sync/deploy activity in that window (sorted by most recent activity, with lastSyncAt on each item). That mode scans all matching applications and may be slow on large ArgoCD instances.',
       {
         search: z
           .string()
           .optional()
           .describe(
             'Search applications by name. This is a partial match on the application name and does not support glob patterns (e.g. "*"). Optional.'
+          ),
+        changedWithinMinutes: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            'When set, only return applications with sync/deploy activity in the last N minutes (uses operation state and sync history timestamps). Results are sorted by most recent activity and include lastSyncAt. Scans all matching applications and may be slow on large instances. Optional.'
           ),
         limit: z
           .number()
@@ -58,9 +66,10 @@ export class Server extends McpServer {
             'Number of applications to skip before returning results. Use with limit for pagination. Optional.'
           )
       },
-      async ({ search, limit, offset }) =>
+      async ({ search, changedWithinMinutes, limit, offset }) =>
         await this.argocdClient.listApplications({
           search: search ?? undefined,
+          changedWithinMinutes,
           limit,
           offset
         })


### PR DESCRIPTION
Add changedWithinMinutes support to return only apps with recent sync/deploy activity, include lastSyncAt, and sort by latest activity. This enables focused queries while keeping list payloads manageable.

This is especially useful during incidents, where we need to quickly
identify which ArgoCD applications changed recently.