### PR TITLE
Fix argocd-mcp version metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dev-sse": "tsx watch src/index.ts sse",
     "lint": "eslint src/**/*.ts --no-warn-ignored",
     "lint:fix": "eslint src/**/*.ts --fix",
+    "test": "pnpm run build && node --test tests/cli-metadata.test.mjs",
     "build": "tsup",
     "build:watch": "tsup --watch",
     "generate-types": "dtsgen -c dtsgen.json -o src/types/argocd.d.ts swagger.json"

--- a/src/cmd/cmd.ts
+++ b/src/cmd/cmd.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import {
@@ -6,8 +8,26 @@ import {
   connectSSETransport
 } from '../server/transport.js';
 
+const readPackageVersion = (): string => {
+  const entrypoint = process.argv[1] ? fs.realpathSync(process.argv[1]) : process.cwd();
+  let dir = path.dirname(path.resolve(entrypoint));
+  for (let i = 0; i < 5; i++) {
+    const packagePath = path.join(dir, 'package.json');
+    if (fs.existsSync(packagePath)) {
+      const packageJSON = JSON.parse(fs.readFileSync(packagePath, 'utf8')) as { version?: unknown };
+      if (typeof packageJSON.version === 'string') return packageJSON.version;
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return 'unknown';
+};
+
 export const cmd = () => {
-  const exe = yargs(hideBin(process.argv));
+  const exe = yargs(hideBin(process.argv)).scriptName('argocd-mcp').version(readPackageVersion());
 
   exe.command(
     'stdio',

--- a/tests/cli-metadata.test.mjs
+++ b/tests/cli-metadata.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+const packDir = await mkdtemp(path.join(os.tmpdir(), 'argocd-mcp-pack-'));
+const packResult = await execFileAsync('pnpm', ['pack', '--pack-destination', packDir], { cwd: root });
+const tarball = packResult.stdout
+  .trim()
+  .split('\n')
+  .find((line) => line.endsWith('.tgz'));
+assert.ok(tarball, 'pnpm pack did not print a tarball path');
+const npmEnv = { ...process.env };
+delete npmEnv.npm_config_npm_globalconfig;
+delete npmEnv.npm_config_verify_deps_before_run;
+delete npmEnv.npm_config__jsr_registry;
+
+test.after(async () => {
+  await rm(packDir, { recursive: true, force: true });
+});
+
+async function runArgocdMcp(args) {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      'npm',
+      ['exec', '--yes', `--package=${tarball}`, '--', 'argocd-mcp', ...args],
+      { cwd: path.dirname(packDir), env: npmEnv }
+    );
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    return {
+      code: error.code,
+      stdout: error.stdout ?? '',
+      stderr: error.stderr ?? ''
+    };
+  }
+}
+
+test('top-level version flag prints the package version', async () => {
+  const result = await runArgocdMcp(['--version']);
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout.trim(), pkg.version);
+  assert.equal(result.stderr.trim(), '');
+});
+
+test('top-level help remains successful', async () => {
+  const result = await runArgocdMcp(['--help']);
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Start ArgoCD MCP server using stdio/);
+  assert.equal(result.stderr.trim(), '');
+});


### PR DESCRIPTION
## Summary
- make the CLI version output explicit instead of relying on yargs package lookup
- resolve the real installed bin path so npm .bin symlinks can still find package.json
- add a packed-tarball metadata test that runs through npm exec

## Reproduction
`npm exec --yes --package=argocd-mcp@0.7.0 -- argocd-mcp --version` currently prints `unknown`.

## Root cause
The published bin runs from an npm .bin symlink and yargs cannot infer the package version in that installed-package path. The new helper resolves the real entrypoint path and walks up to the installed package.json, so it also follows the final package version written by the release workflow.

## Validation
- Red test first: packed tarball test failed with `unknown !== 0.0.0`
- `pnpm run lint`
- `pnpm test`
- local `pnpm pack` + `npm exec --package=<tarball> -- argocd-mcp --version` prints `0.0.0`
- release-order simulation: build first, then `pnpm version 0.7.1 --no-git-tag-version`, then pack; installed tarball prints `0.7.1`
- `git diff --check`