### PR TITLE
feat: support ARGOCD_EXTRA_HEADERS for Argo CD API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ This disables TLS certificate validation for Node.js when connecting to Argo CD 
 
 > **Warning**: Disabling SSL verification reduces security. Use this setting only in development environments or when you understand the security implications.
 
+### Extra HTTP Headers
+
+Some Argo CD deployments sit behind an ingress, SSO gateway, or corporate proxy that requires additional HTTP headers (for example, a session cookie). Set `ARGOCD_EXTRA_HEADERS` to a JSON object of header names and string values; the server attaches them to **every request it makes to Argo CD**:
+
+```
+"ARGOCD_EXTRA_HEADERS": "{\"Cookie\": \"x-og-token=<value>\"}"
+```
+
+This variable is **optional**. When unset or empty, no extra headers are sent and behavior is unchanged.
+
+`Authorization` and `Content-Type` are always set by the server and cannot be overridden by `ARGOCD_EXTRA_HEADERS`. If the variable is set but contains invalid JSON or non-string values, the server fails at startup.
+
+Like other Argo CD credentials, extra headers are read from the environment at server startup — not from MCP tool-call arguments — so secrets stay out of prompts and tool-call logs.
+
 
 ### Providing ArgoCD Credentials
 
@@ -311,13 +325,14 @@ By default neither target sets any credentials — the server starts with no def
 make run PORT=4000
 ```
 
-To configure credentials, export the relevant environment variable on the command line. There are three (all optional):
+To configure credentials, export the relevant environment variable on the command line. There are four (all optional):
 
 | Variable | Purpose |
 |---|---|
 | `ARGOCD_BASE_URL` | Default ArgoCD instance URL used when a call doesn't override it. |
 | `ARGOCD_API_TOKEN` | Static API token for the default base URL. |
 | `ARGOCD_TOKEN_REGISTRY_PATH` | Path to a JSON [token registry](#token-registry--per-base-url-tokens-multi-instance) mapping base URLs to tokens (for targeting multiple instances). |
+| `ARGOCD_EXTRA_HEADERS` | JSON object of [extra HTTP headers](#extra-http-headers) sent on every request to Argo CD (e.g. gateway cookies). |
 
 ```bash
 # Single instance with a static base URL + token:

--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -17,10 +17,10 @@ export class ArgoCDClient {
   private apiToken: string;
   private client: HttpClient;
 
-  constructor(baseUrl: string, apiToken: string) {
+  constructor(baseUrl: string, apiToken: string, extraHeaders: Record<string, string> = {}) {
     this.baseUrl = baseUrl;
     this.apiToken = apiToken;
-    this.client = new HttpClient(this.baseUrl, this.apiToken);
+    this.client = new HttpClient(this.baseUrl, this.apiToken, extraHeaders);
   }
 
   public async listApplications(params?: { search?: string; limit?: number; offset?: number }) {

--- a/src/argocd/extraHeaders.test.ts
+++ b/src/argocd/extraHeaders.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { extraHeadersFromEnv, parseExtraHeaders } from './extraHeaders.js';
+
+test('parseExtraHeaders returns empty object when unset or blank', () => {
+  assert.deepEqual(parseExtraHeaders(undefined), {});
+  assert.deepEqual(parseExtraHeaders(''), {});
+  assert.deepEqual(parseExtraHeaders('   '), {});
+});
+
+test('parseExtraHeaders parses a JSON object of string headers', () => {
+  assert.deepEqual(parseExtraHeaders('{"Cookie": "x-og-token=abc"}'), {
+    Cookie: 'x-og-token=abc'
+  });
+});
+
+test('parseExtraHeaders rejects invalid JSON', () => {
+  assert.throws(() => parseExtraHeaders('{not json'), /valid JSON/);
+});
+
+test('parseExtraHeaders rejects non-object JSON', () => {
+  assert.throws(() => parseExtraHeaders('[]'), /JSON object/);
+  assert.throws(() => parseExtraHeaders('"cookie"'), /JSON object/);
+});
+
+test('parseExtraHeaders rejects non-string header values', () => {
+  assert.throws(() => parseExtraHeaders('{"Cookie": 123}'), /must be a string/);
+});
+
+test('extraHeadersFromEnv reads from the provided env value', () => {
+  assert.deepEqual(extraHeadersFromEnv('{"X-Custom": "value"}'), { 'X-Custom': 'value' });
+});

--- a/src/argocd/extraHeaders.ts
+++ b/src/argocd/extraHeaders.ts
@@ -1,0 +1,31 @@
+// Parse ARGOCD_EXTRA_HEADERS: a JSON object of header names to string values,
+// e.g. {"Cookie": "x-og-token=..."}. Applied to every request to Argo CD.
+export const parseExtraHeaders = (raw: string | undefined): Record<string, string> => {
+  if (!raw?.trim()) {
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('ARGOCD_EXTRA_HEADERS must be valid JSON');
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('ARGOCD_EXTRA_HEADERS must be a JSON object');
+  }
+
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value !== 'string') {
+      throw new Error(`ARGOCD_EXTRA_HEADERS: header "${key}" must be a string value`);
+    }
+    headers[key] = value;
+  }
+  return headers;
+};
+
+export const extraHeadersFromEnv = (
+  raw: string | undefined = process.env.ARGOCD_EXTRA_HEADERS
+): Record<string, string> => parseExtraHeaders(raw);

--- a/src/argocd/http.ts
+++ b/src/argocd/http.ts
@@ -11,10 +11,11 @@ export class HttpClient {
   public readonly apiToken: string;
   public readonly headers: Record<string, string>;
 
-  constructor(baseUrl: string, apiToken: string) {
+  constructor(baseUrl: string, apiToken: string, extraHeaders: Record<string, string> = {}) {
     this.baseUrl = baseUrl;
     this.apiToken = apiToken;
     this.headers = {
+      ...extraHeaders,
       Authorization: `Bearer ${this.apiToken}`,
       'Content-Type': 'application/json'
     };

--- a/src/server/extraHeaders.test.ts
+++ b/src/server/extraHeaders.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createServer } from './server.js';
+import { TokenRegistry } from './tokenRegistry.js';
+
+test('extra headers are attached to Argo CD HTTP requests', () => {
+  const server = createServer({
+    argocdBaseUrl: 'https://argocd.example.com',
+    argocdApiToken: 'token',
+    tokenRegistry: new TokenRegistry(),
+    extraHeaders: { Cookie: 'x-og-token=ccccccxxxxx' }
+  });
+
+  const argoClient = (
+    server as unknown as {
+      resolveClient: (a: { argocdBaseUrl?: string }) => {
+        client: { headers: Record<string, string> };
+      };
+    }
+  ).resolveClient({});
+
+  assert.equal(argoClient.client.headers.Cookie, 'x-og-token=ccccccxxxxx');
+  assert.equal(argoClient.client.headers.Authorization, 'Bearer token');
+});
+
+test('Authorization cannot be overridden by extra headers', () => {
+  const server = createServer({
+    argocdBaseUrl: 'https://argocd.example.com',
+    argocdApiToken: 'real-token',
+    tokenRegistry: new TokenRegistry(),
+    extraHeaders: { Authorization: 'Bearer evil' }
+  });
+
+  const argoClient = (
+    server as unknown as {
+      resolveClient: (a: { argocdBaseUrl?: string }) => {
+        client: { headers: Record<string, string> };
+      };
+    }
+  ).resolveClient({});
+
+  assert.equal(argoClient.client.headers.Authorization, 'Bearer real-token');
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -17,6 +17,9 @@ type ServerInfo = {
   // Optional registry mapping additional ArgoCD base URLs to their tokens. When
   // omitted, it is loaded from the ARGOCD_TOKEN_REGISTRY_PATH env var.
   tokenRegistry?: TokenRegistry;
+  // Optional extra HTTP headers for every Argo CD API request (from
+  // ARGOCD_EXTRA_HEADERS). Authorization and Content-Type cannot be overridden.
+  extraHeaders?: Record<string, string>;
 };
 
 // Per-call argument that any tool may accept to target a specific ArgoCD
@@ -45,6 +48,7 @@ export class Server extends McpServer {
   private defaultApiToken: string;
   private tokenRegistry: TokenRegistry;
   private argocdClient: ArgoCDClient;
+  private extraHeaders: Record<string, string>;
   // Cache per-credential clients to avoid rebuilding the HttpClient on every
   // call. Keyed by baseUrl + token, since the same base URL may resolve to
   // different tokens (request token vs. registry token vs. default).
@@ -58,7 +62,12 @@ export class Server extends McpServer {
     this.defaultBaseUrl = serverInfo.argocdBaseUrl;
     this.defaultApiToken = serverInfo.argocdApiToken;
     this.tokenRegistry = serverInfo.tokenRegistry ?? tokenRegistryFromEnv();
-    this.argocdClient = new ArgoCDClient(serverInfo.argocdBaseUrl, serverInfo.argocdApiToken);
+    this.extraHeaders = serverInfo.extraHeaders ?? {};
+    this.argocdClient = new ArgoCDClient(
+      serverInfo.argocdBaseUrl,
+      serverInfo.argocdApiToken,
+      this.extraHeaders
+    );
 
     const isReadOnly =
       String(process.env.MCP_READ_ONLY ?? '')
@@ -431,7 +440,7 @@ export class Server extends McpServer {
     const cacheKey = `${baseUrl} ${apiToken}`;
     let client = this.clientCache.get(cacheKey);
     if (!client) {
-      client = new ArgoCDClient(baseUrl, apiToken);
+      client = new ArgoCDClient(baseUrl, apiToken, this.extraHeaders);
       this.clientCache.set(cacheKey, client);
     }
     return client;

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -6,18 +6,21 @@ import { createServer } from './server.js';
 import { randomUUID } from 'node:crypto';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { extraHeadersFromEnv } from '../argocd/extraHeaders.js';
 import { tokenRegistryFromEnv } from './tokenRegistry.js';
 
 // Load the base-URL -> token registry once at startup from the JSON file at
 // ARGOCD_TOKEN_REGISTRY_PATH. Shared across all connections; read-only after
 // construction.
 const tokenRegistry = tokenRegistryFromEnv();
+const extraHeaders = extraHeadersFromEnv();
 
 export const connectStdioTransport = () => {
   const server = createServer({
     argocdBaseUrl: process.env.ARGOCD_BASE_URL || '',
     argocdApiToken: process.env.ARGOCD_API_TOKEN || '',
-    tokenRegistry
+    tokenRegistry,
+    extraHeaders
   });
 
   logger.info('Connecting to stdio transport');
@@ -32,7 +35,8 @@ export const connectSSETransport = (port: number) => {
     const server = createServer({
       argocdBaseUrl: (req.headers['x-argocd-base-url'] as string) || '',
       argocdApiToken: (req.headers['x-argocd-api-token'] as string) || '',
-      tokenRegistry
+      tokenRegistry,
+      extraHeaders
     });
 
     const transport = new SSEServerTransport('/messages', res);
@@ -127,7 +131,7 @@ export const connectHttpTransport = (port: number, stateless = false) => {
         };
       }
 
-      const server = createServer({ ...credentials, tokenRegistry });
+      const server = createServer({ ...credentials, tokenRegistry, extraHeaders });
       await server.connect(transport);
     } else {
       const errorMsg = sessionIdFromHeader


### PR DESCRIPTION
## Summary

Some Argo CD instances are reachable only through an org-internal gateway or SSO proxy that requires additional HTTP headers (for example, a session cookie). This PR adds optional support for passing those headers via the `ARGOCD_EXTRA_HEADERS` environment variable.

- Parse `ARGOCD_EXTRA_HEADERS` as a JSON object of header name → string value at server startup
- Attach the headers to every MCP server → Argo CD API request (stdio, SSE, and HTTP transports)
- Keep `Authorization` and `Content-Type` server-controlled so the Argo CD API token cannot be overridden
- Document the new env var in the README and add it to the local development configuration table

The variable is **optional**. When unset or empty, behavior is unchanged.

## Example

```json
{
  "mcpServers": {
    "argocd-mcp": {
      "command": "npx",
      "args": ["argocd-mcp@latest", "stdio"],
      "env": {
        "ARGOCD_BASE_URL": "https://argocd.example.com",
        "ARGOCD_API_TOKEN": "<token>",
        "ARGOCD_EXTRA_HEADERS": "{\"Cookie\": \"x-og-token=<value>\"}"
      }
    }
  }
}
```

## Security notes

- Extra headers are read from the environment at startup, not from MCP tool-call arguments, consistent with how API tokens are handled
- Invalid JSON or non-string header values cause the server to fail at startup (fail closed)
- `Authorization` cannot be overridden via `ARGOCD_EXTRA_HEADERS`

## Test plan

- [x] `pnpm test` — 30/30 pass (includes parsing, header attachment, and Authorization override protection)
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] Manual verification against an org-internal Argo CD instance behind a gateway cookie