### PR TITLE
feat: add ArgoCD profile management based on ArgoCD CLI produced config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ const urlForGithub = `https://insiders.vscode.dev/redirect?url=${encodeURICompon
 
 The server provides the following ArgoCD management tools:
 
+### Profile Management
+- `list_profiles`: List the configured ArgoCD profiles (named instances) and the active/default one
+- `get_current_profile`: Get the profile active for the current session
+- `set_profile`: Select the active profile by name (see [Profiles](#profiles--multiple-instances-from-your-argo-cd-cli-config))
+
 ### Cluster Management
 - `list_clusters`: List all clusters registered with ArgoCD
 
@@ -163,7 +168,7 @@ The ArgoCD **API token is a secret and is only ever read from the transport laye
 
 This token is **outbound only**: it authenticates this server to ArgoCD and never authorizes an inbound caller. See [Network Exposure](#network-exposure) for who may reach the listener.
 
-This is the **default token**. It is **mandatory unless a [token registry](#token-registry--per-base-url-tokens-multi-instance) is configured**: on the HTTP transport, a connection that supplies no token (neither header nor env var) is rejected with `400 Bad Request`, but when a registry is configured a tokenless connection is allowed because each call resolves its own [registry token](#two-kinds-of-token). Keeping the token out of tool arguments ensures it never enters prompts, model context, or tool-call logs.
+This is the **default token**. It is **mandatory unless [profiles](#profiles--multiple-instances-from-your-argo-cd-cli-config) are configured**: on the HTTP transport, a connection that supplies no token (neither header nor env var) is rejected with `400 Bad Request`, but when profiles are configured a tokenless connection is allowed because each call resolves its own [profile token](#two-kinds-of-token). Keeping the token out of tool arguments ensures it never enters prompts, model context, or tool-call logs.
 
 #### Base URL — header / env var, or per-call argument
 
@@ -177,53 +182,57 @@ In addition, **every tool accepts an optional `argocdBaseUrl` argument**:
 - If a session default base URL exists, `argocdBaseUrl` is **optional** and overrides the default for that single call.
 - If no session default base URL is configured (header and env var both absent), `argocdBaseUrl` is **required**; a call without it returns an error.
 
-#### Token registry — per-base-URL tokens (multi-instance)
+#### Profiles — multiple instances from your Argo CD CLI config
 
-To target **multiple ArgoCD instances, each with its own token**, configure a token registry. Because the tokens are secrets, the registry is **read from a JSON file**, not an environment variable — point `ARGOCD_TOKEN_REGISTRY_PATH` at the file (e.g. a mounted Kubernetes secret). This keeps the tokens out of the process environment, crash dumps, and child-process inheritance.
+To target **multiple ArgoCD instances**, point the server at your existing **Argo CD CLI config file** — the one written by `argocd login` / `argocd context` (default location `~/.config/argocd/config`). Every context in it becomes a selectable **profile**, reusing the credentials you already have, including tokens obtained via **SSO/OIDC or LDAP** through `argocd login --sso`. No separate token file to maintain.
+
+Reading the config is **opt-in**: provide the path explicitly via the `--config` flag or the `ARGOCD_CONFIG` environment variable. The default `~/.config/argocd/config` location is **never read implicitly**.
 
 ```bash
-ARGOCD_TOKEN_REGISTRY_PATH=/app/argocd-mcp/token-registry.json
+# CLI flag
+argocd-mcp stdio --config ~/.config/argocd/config
+# or environment variable
+ARGOCD_CONFIG=~/.config/argocd/config argocd-mcp stdio
 ```
 
-The file contains a JSON array mapping a base URL to the token that should be used for it:
+Each context maps to a profile: its `server` becomes the base URL (`https://`, or `http://` when the matching `servers` entry is marked `plain-text`), and the linked user's `auth-token` becomes the token. The file's `current-context` becomes the **default/active** profile. Contexts with no `auth-token` (never logged in, or an expired session) are skipped with a warning.
 
-```json
-[
-  { "baseUrl": "https://argo-a.example.com", "token": "<token-a>" },
-  { "baseUrl": "https://argo-b.example.com", "token": "<token-b>" }
-]
-```
+Three tools manage the active profile **per session** — profile names are **non-secret**, but tokens are **never** exposed by any of them:
 
-> **Secure the file.** Restrict it to the server's user (e.g. `chmod 400`) and prefer a secret-management mechanism (Kubernetes secret volume, Vault agent, etc.) over a plaintext file on disk.
+- `list_profiles` — lists the configured profiles as `{ name, baseUrl }` (never tokens), plus which profile is currently `active` and which is the `default`.
+- `get_current_profile` — returns the profile active for this session (or the default base URL when none is active).
+- `set_profile` — selects the active profile by `name` (case-insensitive). Subsequent tool calls that don't pass an `argocdBaseUrl` override target that profile's instance.
 
-> **Local development.** The `make run` / `make dev` targets run without a registry by default; pass `ARGOCD_TOKEN_REGISTRY_PATH=/path/to/tokens.json` to use one. Do **not** place the file under `dist/` — `tsup` runs with `clean: true` and wipes that directory on every build. See [Running locally](#running-locally).
+> **Secure the file.** The config holds bearer tokens, so restrict it to the server's user (the `argocd` CLI writes it `0600` by default) and prefer a secret-management mechanism (Kubernetes secret volume, Vault agent, etc.) over a plaintext file when deploying.
 
-With a registry configured, a caller targets an instance by passing only the (non-secret) `argocdBaseUrl` argument; the server pairs it with the registered token. The token never appears in the tool-call payload.
+> **Stateless HTTP mode.** In [stateless mode](#stateless-mode) a fresh server is built per request, so `set_profile` does not persist across requests — it returns a warning to that effect. Rely on the `current-context` default profile instead.
+
+The per-call `argocdBaseUrl` argument still takes precedence over the active profile for a single call, and is still subject to the token boundary below.
 
 ##### Two kinds of token
 
 The server resolves calls using one of two distinct tokens. Keeping them straight is what makes the security model work:
 
-| | **Default token** | **Registry token** |
+| | **Default token** | **Profile token** |
 |---|---|---|
-| **Source** | `x-argocd-api-token` header / `ARGOCD_API_TOKEN` env var (the session credential) | A `token` entry in the `ARGOCD_TOKEN_REGISTRY_PATH` JSON file, keyed by `baseUrl` |
-| **Scope** | The **default base URL only** (`x-argocd-base-url` / `ARGOCD_BASE_URL`) | The **specific base URL** its entry is keyed to |
-| **Used for** | A call that targets the default base URL | A call that targets any base URL present in the registry (including the default, as a fallback) |
-| **Never used for** | Any base URL other than the default — it is **never** sent to a different host | Any base URL not registered |
+| **Source** | `x-argocd-api-token` header / `ARGOCD_API_TOKEN` env var (the session credential) | A context's `auth-token` in the Argo CD CLI config, keyed by its base URL |
+| **Scope** | The **default base URL only** (`x-argocd-base-url` / `ARGOCD_BASE_URL`) | The **specific base URL** of that profile |
+| **Used for** | A call that targets the default base URL | A call that targets any profile's base URL (including the default, as a fallback) |
+| **Never used for** | Any base URL other than the default — it is **never** sent to a different host | Any base URL not present in the config |
 
-The cardinal rule: **the default token is bound to the default base URL; every other host's token must come from the registry.** A registry token is bound to exactly the host it is registered under.
+The cardinal rule: **the default token is bound to the default base URL; every other host's token must come from a configured profile.** A profile token is bound to exactly the host it is configured for.
 
 ##### Resolution order
 
-For a given call, the resolved base URL is the `argocdBaseUrl` argument if supplied, otherwise the session default. The token is then chosen by:
+For a given call, the resolved base URL is the `argocdBaseUrl` argument if supplied, otherwise the active profile's base URL, otherwise the session default. The token is then chosen by:
 
-1. **Call targets the default base URL** → use the **default token**. If no default token was supplied (a tokenless session), fall back to the **registry token** for that base URL, if one exists.
-2. **Call targets any other base URL** → use the **registry token** for that base URL only. The **default token is never used here** — it is not sent to a host other than the default one.
+1. **Call targets the default base URL** → use the **default token**. If no default token was supplied (a tokenless session), fall back to the **profile token** for that base URL, if one exists.
+2. **Call targets any other base URL** → use the **profile token** for that base URL only. The **default token is never used here** — it is not sent to a host other than the default one.
 3. If neither applies (no token can be resolved for the requested base URL), the call returns a "Missing required ArgoCD API token" error and **no request is made** to that host.
 
-> **Why the default token is bound to the default base URL.** The `argocdBaseUrl` argument comes from the tool call, so a caller (or a prompt-injected model) could point it at an arbitrary host. If the default token were paired with any supplied base URL, that token would be sent — as an `Authorization: Bearer` header — to the attacker's host. Restricting the default token to the default base URL, and requiring an explicit registry entry for every other host, prevents this token exfiltration. To target additional instances you must register their tokens (and thus their hostnames) up front.
+> **Why the default token is bound to the default base URL.** The `argocdBaseUrl` argument comes from the tool call, so a caller (or a prompt-injected model) could point it at an arbitrary host. If the default token were paired with any supplied base URL, that token would be sent — as an `Authorization: Bearer` header — to the attacker's host. Restricting the default token to the default base URL, and requiring a configured profile for every other host, prevents this token exfiltration.
 
-Base URLs are normalized for lookup (lowercased host, trailing slashes ignored), so minor formatting differences still match. When a registry is configured, the HTTP transport no longer requires `x-argocd-api-token` at connection time — a tokenless connection is allowed because the per-call base URL resolves its own token. If `ARGOCD_TOKEN_REGISTRY_PATH` is set but the file is missing, unreadable, or malformed, the server **fails closed**: it throws at startup rather than silently falling back to its default credential, so a misconfigured registry can never cause calls to be routed with the wrong token.
+Base URLs are normalized for lookup (lowercased host, trailing slashes ignored), so minor formatting differences still match. When profiles are configured, the HTTP transport no longer requires `x-argocd-api-token` at connection time — a tokenless connection is allowed because the per-call base URL resolves its own token. If `--config` / `ARGOCD_CONFIG` is set but the file is missing, unreadable, or malformed, the server **fails closed**: it throws at startup rather than silently running with no profiles.
 
 For example, a `tools/call` request overriding only the base URL:
 
@@ -241,7 +250,7 @@ For example, a `tools/call` request overriding only the base URL:
 }
 ```
 
-> **Overriding the base URL to a different instance requires a registry token.** The default token (`x-argocd-api-token` / `ARGOCD_API_TOKEN`) is bound to the default base URL only and is never sent to a different host. Overriding `argocdBaseUrl` to point at the **default** instance (same host, formatting aside) reuses the default token; pointing it at any **other** instance requires a [registry token](#two-kinds-of-token) for that instance, otherwise the call fails with "Missing required ArgoCD API token" and no request is sent. This is intentional — see [why the default token is bound to the default base URL](#token-registry--per-base-url-tokens-multi-instance) above.
+> **Overriding the base URL to a different instance requires a configured profile.** The default token (`x-argocd-api-token` / `ARGOCD_API_TOKEN`) is bound to the default base URL only and is never sent to a different host. Overriding `argocdBaseUrl` to point at the **default** instance (same host, formatting aside) reuses the default token; pointing it at any **other** instance requires a profile for that instance in your Argo CD CLI config, otherwise the call fails with "Missing required ArgoCD API token" and no request is sent. This is intentional — see [why the default token is bound to the default base URL](#profiles--multiple-instances-from-your-argo-cd-cli-config) above. Selecting a profile by name with `set_profile` is the convenient alternative to passing raw base URLs.
 
 ### Network Exposure
 
@@ -369,7 +378,7 @@ make run    # build, then run the HTTP server (production-style)
 make dev    # run from source with hot reloading (tsx watch)
 ```
 
-By default neither target sets any credentials — the server starts with no default base URL or token, so callers must supply them per request (`x-argocd-base-url` / `x-argocd-api-token` headers, or the `argocdBaseUrl` tool argument once a registry is configured). Override the port the same way:
+By default neither target sets any credentials — the server starts with no default base URL or token, so callers must supply them per request (`x-argocd-base-url` / `x-argocd-api-token` headers, or the `argocdBaseUrl` tool argument once profiles are configured). Override the port the same way:
 
 ```bash
 make run PORT=4000
@@ -381,7 +390,7 @@ To configure credentials, export the relevant environment variable on the comman
 |---|---|
 | `ARGOCD_BASE_URL` | Default ArgoCD instance URL used when a call doesn't override it. |
 | `ARGOCD_API_TOKEN` | Static API token for the default base URL. |
-| `ARGOCD_TOKEN_REGISTRY_PATH` | Path to a JSON [token registry](#token-registry--per-base-url-tokens-multi-instance) mapping base URLs to tokens (for targeting multiple instances). |
+| `ARGOCD_CONFIG` | Path to an [Argo CD CLI config file](#profiles--multiple-instances-from-your-argo-cd-cli-config) whose contexts are loaded as profiles (for targeting multiple instances). Equivalent to the `--config` flag. |
 
 These are all outbound credentials. For who may reach the listener, see [Network Exposure](#network-exposure).
 
@@ -389,26 +398,26 @@ These are all outbound credentials. For who may reach the listener, see [Network
 # Single instance with a static base URL + token:
 make run ARGOCD_BASE_URL=https://argo.example.com ARGOCD_API_TOKEN=<token>
 
-# Multiple instances via a token registry:
-make run ARGOCD_TOKEN_REGISTRY_PATH=/path/to/tokens.json
+# Multiple instances via your Argo CD CLI config (each context becomes a profile):
+make run ARGOCD_CONFIG=~/.config/argocd/config
 
-# Both — a default instance plus extra instances resolved from the registry:
+# Both — a default base URL/token plus profiles resolved from the config:
 make dev ARGOCD_BASE_URL=https://argo.example.com ARGOCD_API_TOKEN=<token> \
-  ARGOCD_TOKEN_REGISTRY_PATH=/path/to/tokens.json
+  ARGOCD_CONFIG=~/.config/argocd/config
 ```
 
-See [Token resolution](#token-registry--per-base-url-tokens-multi-instance) for how the default token and registry interact. If `ARGOCD_TOKEN_REGISTRY_PATH` is set but the file is missing, unreadable, or malformed, the server fails closed at startup.
+See [Profiles](#profiles--multiple-instances-from-your-argo-cd-cli-config) for how the default token and profile tokens interact. If `ARGOCD_CONFIG` is set but the file is missing, unreadable, or malformed, the server fails closed at startup.
 
 > **Keep tokens out of your shell history.** Passing `ARGOCD_API_TOKEN=<token>` directly on the `make` command line records the secret in your shell history and exposes it in the process list. Prefer exporting it in the shell first so it never appears in the `make` invocation:
 > ```bash
 > export ARGOCD_API_TOKEN=<token>
 > make run ARGOCD_BASE_URL=https://argo.example.com
 > ```
-> A registry path (`ARGOCD_TOKEN_REGISTRY_PATH`) and base URL are not secrets, so they're fine to pass inline.
+> A config path (`ARGOCD_CONFIG`) and base URL are not secrets, so they're fine to pass inline.
 
 > Do not place the registry file under `dist/` — `tsup` builds with `clean: true` and wipes that directory on every build.
 
-The HTTP server listens on `POST /mcp` (`127.0.0.1:3000` by default, see [Network Exposure](#network-exposure) to widen it) with a `GET /healthz` liveness endpoint. To send a request, first `initialize` a session (capture the `mcp-session-id` response header), then call a tool, passing one of the registered base URLs as the `argocdBaseUrl` argument:
+The HTTP server listens on `POST /mcp` (`127.0.0.1:3000` by default, see [Network Exposure](#network-exposure) to widen it) with a `GET /healthz` liveness endpoint. To send a request, first `initialize` a session (capture the `mcp-session-id` response header), then call a tool, passing one of your configured base URLs as the `argocdBaseUrl` argument (or select a profile with `set_profile`):
 
 ```bash
 # 1. Initialize a session — note the mcp-session-id response header

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,13 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "js-yaml": "^4.1.0",
         "pino": "^9.6.0",
         "yargs": "^17.7.2",
-        "zod": "^3.24.3"
+        "zod": "^3.25.0"
       },
       "bin": {
         "argocd-mcp": "dist/index.js"
@@ -23,6 +24,7 @@
         "@dtsgenerator/replace-namespace": "^1.7.0",
         "@eslint/js": "^9.25.0",
         "@types/express": "^5.0.1",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.14.1",
         "@types/yargs": "^17.0.33",
         "dtsgenerator": "^3.19.2",
@@ -730,9 +732,10 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1174,6 +1177,13 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1610,8 +1620,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -2990,7 +2999,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "js-yaml": "^4.1.0",
     "pino": "^9.6.0",
     "yargs": "^17.7.2",
     "zod": "^3.25.0"
@@ -60,6 +61,7 @@
     "@dtsgenerator/replace-namespace": "^1.7.0",
     "@eslint/js": "^9.25.0",
     "@types/express": "^5.0.1",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.14.1",
     "@types/yargs": "^17.0.33",
     "dtsgenerator": "^3.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       pino:
         specifier: ^9.6.0
         version: 9.6.0
@@ -36,6 +39,9 @@ importers:
       '@types/express':
         specifier: ^5.0.1
         version: 5.0.1
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1
@@ -267,7 +273,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==, tarball: https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz}
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -315,7 +321,7 @@ packages:
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
   '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==, tarball: https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz}
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -378,56 +384,67 @@ packages:
     resolution: {integrity: sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.40.0':
     resolution: {integrity: sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.40.0':
     resolution: {integrity: sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.40.0':
     resolution: {integrity: sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.40.0':
     resolution: {integrity: sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.40.0':
     resolution: {integrity: sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.40.0':
     resolution: {integrity: sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.40.0':
     resolution: {integrity: sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.40.0':
     resolution: {integrity: sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.40.0':
     resolution: {integrity: sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.40.0':
     resolution: {integrity: sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.40.0':
     resolution: {integrity: sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==}
@@ -461,6 +478,9 @@ packages:
 
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -555,7 +575,7 @@ packages:
     engines: {node: '>= 14'}
 
   ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==, tarball: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz}
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -566,7 +586,7 @@ packages:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==, tarball: https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz}
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -602,7 +622,7 @@ packages:
     engines: {node: '>=18'}
 
   body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==, tarball: https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz}
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   brace-expansion@1.1.12:
@@ -692,7 +712,7 @@ packages:
     engines: {node: '>= 0.6'}
 
   cors@2.8.5:
-    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==, tarball: https://registry.npmjs.org/cors/-/cors-2.8.5.tgz}
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
 
   cross-fetch@4.1.0:
@@ -712,7 +732,7 @@ packages:
         optional: true
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==, tarball: https://registry.npmjs.org/debug/-/debug-4.4.3.tgz}
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -851,15 +871,15 @@ packages:
     engines: {node: '>= 0.6'}
 
   eventsource-parser@3.0.1:
-    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==, tarball: https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz}
+    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.6:
-    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==, tarball: https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz}
+    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==}
     engines: {node: '>=18.0.0'}
 
   express-rate-limit@8.4.0:
-    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==, tarball: https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz}
+    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -869,7 +889,7 @@ packages:
     engines: {node: '>= 18'}
 
   express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==, tarball: https://registry.npmjs.org/express/-/express-5.2.1.tgz}
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
@@ -893,7 +913,7 @@ packages:
     engines: {node: '>=6'}
 
   fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==, tarball: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz}
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1000,7 +1020,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==, tarball: https://registry.npmjs.org/hono/-/hono-4.12.14.tgz}
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.0:
@@ -1008,7 +1028,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==, tarball: https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz}
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
@@ -1024,7 +1044,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==, tarball: https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz}
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -1043,7 +1063,7 @@ packages:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==, tarball: https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz}
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1076,7 +1096,7 @@ packages:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jose@6.2.2:
-    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==, tarball: https://registry.npmjs.org/jose/-/jose-6.2.2.tgz}
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1093,10 +1113,10 @@ packages:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz}
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==, tarball: https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz}
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1277,7 +1297,7 @@ packages:
     engines: {node: '>= 6'}
 
   pkce-challenge@5.0.0:
-    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==, tarball: https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz}
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
 
   postcss-load-config@6.0.1:
@@ -1327,7 +1347,7 @@ packages:
     engines: {node: '>=0.6'}
 
   qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.1.tgz}
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -1345,7 +1365,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==, tarball: https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz}
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
   readdirp@4.1.2:
@@ -1361,7 +1381,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==, tarball: https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz}
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
@@ -1461,7 +1481,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==, tarball: https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz}
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   string-width@4.2.3:
@@ -1651,12 +1671,12 @@ packages:
     engines: {node: '>=10'}
 
   zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==, tarball: https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz}
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
 
   zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==, tarball: https://registry.npmjs.org/zod/-/zod-3.25.76.tgz}
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -1951,6 +1971,8 @@ snapshots:
       '@types/serve-static': 1.15.7
 
   '@types/http-errors@2.0.4': {}
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/src/argocd/localConfig.test.ts
+++ b/src/argocd/localConfig.test.ts
@@ -1,0 +1,251 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  argoCdRegistrySource,
+  parseArgoCdLocalConfig,
+  tokenRegistryFromArgoCdConfig
+} from './localConfig.js';
+
+// A representative Argo CD CLI config (the shape written by `argocd login`),
+// with two contexts: a default HTTPS one and a plain-text one.
+const SAMPLE_CONFIG = `
+contexts:
+- name: prod
+  server: argo-prod.example.com
+  user: prod
+- name: local
+  server: argo-local.example.com
+  user: local
+current-context: prod
+servers:
+- server: argo-prod.example.com
+  grpc-web: true
+- server: argo-local.example.com
+  plain-text: true
+users:
+- name: prod
+  auth-token: token-prod
+  refresh-token: refresh-prod
+- name: local
+  auth-token: token-local
+`;
+
+const withConfigFile = (contents: string): { path: string; cleanup: () => void } => {
+  const dir = mkdtempSync(join(tmpdir(), 'argocd-config-test-'));
+  const path = join(dir, 'config');
+  writeFileSync(path, contents, 'utf8');
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+};
+
+// --- parseArgoCdLocalConfig ----------------------------------------------
+
+test('parseArgoCdLocalConfig maps contexts to profile entries with the right scheme', () => {
+  const { entries, currentContext } = parseArgoCdLocalConfig(SAMPLE_CONFIG);
+  assert.equal(currentContext, 'prod');
+  assert.deepEqual(entries, [
+    { name: 'prod', baseUrl: 'https://argo-prod.example.com', token: 'token-prod', default: true },
+    {
+      name: 'local',
+      baseUrl: 'http://argo-local.example.com',
+      token: 'token-local',
+      default: false
+    }
+  ]);
+});
+
+test('parseArgoCdLocalConfig skips contexts without an auth-token', () => {
+  const config = `
+contexts:
+- name: prod
+  server: argo-prod.example.com
+  user: prod
+- name: loggedout
+  server: argo-out.example.com
+  user: loggedout
+current-context: prod
+users:
+- name: prod
+  auth-token: token-prod
+- name: loggedout
+  refresh-token: only-refresh
+`;
+  const { entries } = parseArgoCdLocalConfig(config);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].name, 'prod');
+});
+
+test('parseArgoCdLocalConfig defaults to HTTPS when no matching server entry exists', () => {
+  const config = `
+contexts:
+- name: prod
+  server: argo-prod.example.com
+  user: prod
+users:
+- name: prod
+  auth-token: token-prod
+`;
+  const { entries } = parseArgoCdLocalConfig(config);
+  assert.equal(entries[0].baseUrl, 'https://argo-prod.example.com');
+});
+
+test('parseArgoCdLocalConfig falls back to the context name when user is omitted', () => {
+  const config = `
+contexts:
+- name: prod
+  server: argo-prod.example.com
+users:
+- name: prod
+  auth-token: token-prod
+`;
+  const { entries } = parseArgoCdLocalConfig(config);
+  assert.equal(entries[0].token, 'token-prod');
+});
+
+test('parseArgoCdLocalConfig throws on malformed YAML', () => {
+  assert.throws(() => parseArgoCdLocalConfig('this: : : not yaml'), /not valid YAML/);
+});
+
+test('parseArgoCdLocalConfig throws when the document is not a mapping', () => {
+  assert.throws(() => parseArgoCdLocalConfig('- just\n- a\n- list'), /must contain a YAML mapping/);
+});
+
+// --- tokenRegistryFromArgoCdConfig ---------------------------------------
+
+test('tokenRegistryFromArgoCdConfig returns an empty registry when no path is given', () => {
+  assert.equal(tokenRegistryFromArgoCdConfig(undefined).listProfiles().length, 0);
+  assert.equal(tokenRegistryFromArgoCdConfig('').getSize(), 0);
+  assert.equal(tokenRegistryFromArgoCdConfig('   ').getSize(), 0);
+});
+
+test('tokenRegistryFromArgoCdConfig loads profiles + tokens from a config file', () => {
+  const { path, cleanup } = withConfigFile(SAMPLE_CONFIG);
+  try {
+    const registry = tokenRegistryFromArgoCdConfig(path);
+    assert.deepEqual(registry.listProfiles(), [
+      { name: 'prod', baseUrl: 'https://argo-prod.example.com' },
+      { name: 'local', baseUrl: 'http://argo-local.example.com' }
+    ]);
+    assert.equal(registry.getDefaultProfileName(), 'prod');
+    // Tokens are routable but never surface in the profile list.
+    assert.equal(registry.getToken('https://argo-prod.example.com'), 'token-prod');
+    assert.ok(!JSON.stringify(registry.listProfiles()).includes('token-prod'));
+  } finally {
+    cleanup();
+  }
+});
+
+test('tokenRegistryFromArgoCdConfig throws (fail closed) when the configured file is missing', () => {
+  assert.throws(
+    () => tokenRegistryFromArgoCdConfig('/nonexistent/path/config'),
+    /Failed to read Argo CD config file/
+  );
+});
+
+test('tokenRegistryFromArgoCdConfig throws (fail closed) when the file is malformed', () => {
+  const { path, cleanup } = withConfigFile('this: : : not yaml');
+  try {
+    assert.throws(() => tokenRegistryFromArgoCdConfig(path), /not valid YAML/);
+  } finally {
+    cleanup();
+  }
+});
+
+// --- argoCdRegistrySource (opportunistic reload) -------------------------
+
+const ONE_CONTEXT = `
+contexts:
+- name: prod
+  server: argo-prod.example.com
+  user: prod
+current-context: prod
+users:
+- name: prod
+  auth-token: token-prod
+`;
+
+test('argoCdRegistrySource with no path is a fixed empty registry', () => {
+  const source = argoCdRegistrySource(undefined);
+  assert.equal(source.get().listProfiles().length, 0);
+  assert.equal(source.reload().listProfiles().length, 0);
+});
+
+test('argoCdRegistrySource eager-loads and fails closed on a bad path', () => {
+  assert.throws(
+    () => argoCdRegistrySource('/nonexistent/path/config'),
+    /Failed to read Argo CD config file/
+  );
+});
+
+test('argoCdRegistrySource.reload() picks up a profile added after startup', () => {
+  const { path, cleanup } = withConfigFile(ONE_CONTEXT);
+  try {
+    const source = argoCdRegistrySource(path);
+    assert.deepEqual(
+      source
+        .get()
+        .listProfiles()
+        .map((p) => p.name),
+      ['prod']
+    );
+
+    // A new `argocd login` adds a second context while the server runs.
+    writeFileSync(
+      path,
+      `
+contexts:
+- name: prod
+  server: argo-prod.example.com
+  user: prod
+- name: staging
+  server: argo-staging.example.com
+  user: staging
+current-context: prod
+users:
+- name: prod
+  auth-token: token-prod
+- name: staging
+  auth-token: token-staging
+`,
+      'utf8'
+    );
+
+    // get() still reflects the previously loaded state until a reload.
+    assert.equal(source.get().listProfiles().length, 1);
+    // reload() re-reads and now sees both profiles.
+    assert.deepEqual(
+      source
+        .reload()
+        .listProfiles()
+        .map((p) => p.name),
+      ['prod', 'staging']
+    );
+    // ...and get() reflects the refreshed registry afterwards.
+    assert.equal(source.get().listProfiles().length, 2);
+  } finally {
+    cleanup();
+  }
+});
+
+test('argoCdRegistrySource.reload() keeps the previous registry when the file becomes malformed', () => {
+  const { path, cleanup } = withConfigFile(ONE_CONTEXT);
+  try {
+    const source = argoCdRegistrySource(path);
+    assert.equal(source.get().listProfiles().length, 1);
+
+    writeFileSync(path, 'this: : : not yaml', 'utf8');
+    // A failed reload must not wipe or crash — the last good registry is kept.
+    assert.deepEqual(
+      source
+        .reload()
+        .listProfiles()
+        .map((p) => p.name),
+      ['prod']
+    );
+    assert.equal(source.get().listProfiles().length, 1);
+  } finally {
+    cleanup();
+  }
+});

--- a/src/argocd/localConfig.ts
+++ b/src/argocd/localConfig.ts
@@ -1,0 +1,191 @@
+import { readFileSync } from 'node:fs';
+import yaml from 'js-yaml';
+import { logger } from '../logging/logging.js';
+import { TokenRegistry, type TokenRegistryEntry } from '../server/tokenRegistry.js';
+
+// Reads the Argo CD CLI's local config file (the one written by `argocd login`,
+// `argocd context`, etc.) and turns its contexts into selectable MCP profiles.
+//
+// This lets the server reuse the credentials a user already has — including
+// tokens obtained via SSO/OIDC or LDAP through `argocd login --sso` — instead
+// of duplicating them into a separate file. Each context becomes a profile
+// (name -> base URL + token), and the file's `current-context` becomes the
+// default/active profile.
+//
+// The config is read ONLY when an explicit path is provided (the ARGOCD_CONFIG
+// env var or the --config CLI flag); the default `~/.config/argocd/config`
+// location is never read implicitly. Tokens are secrets, so reading them from
+// the user's own protected file keeps them out of tool-call payloads, prompts,
+// and model context, exactly like the rest of the credential handling.
+
+// The relevant subset of the Argo CD CLI config file. Field names match the
+// YAML keys written by the argocd CLI (see argo-cd util/localconfig).
+type ArgoCdContext = {
+  name?: string;
+  server?: string;
+  user?: string;
+};
+
+type ArgoCdServer = {
+  server?: string;
+  // When true the server is served over plain HTTP rather than HTTPS.
+  'plain-text'?: boolean;
+};
+
+type ArgoCdUser = {
+  name?: string;
+  'auth-token'?: string;
+};
+
+type ArgoCdLocalConfig = {
+  contexts?: ArgoCdContext[];
+  servers?: ArgoCdServer[];
+  users?: ArgoCdUser[];
+  'current-context'?: string;
+};
+
+// Build the base URL the MCP server should call for a given context. The config
+// stores a bare host (e.g. "argocd.example.com"); the REST API is HTTPS unless
+// the matching server entry is marked plain-text.
+const toBaseUrl = (server: string, plainText: boolean): string =>
+  `${plainText ? 'http' : 'https'}://${server}`;
+
+// Parse the raw YAML contents of an Argo CD CLI config file into profile
+// registry entries plus the name of the current context (the default profile).
+// Throws on malformed YAML — an operator who pointed us at a config file expects
+// it to be usable, so we surface the problem loudly rather than silently degrade.
+export const parseArgoCdLocalConfig = (
+  raw: string
+): { entries: TokenRegistryEntry[]; currentContext?: string } => {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(raw);
+  } catch (error) {
+    throw new Error(
+      `Argo CD config file is not valid YAML: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Argo CD config file must contain a YAML mapping');
+  }
+  const config = parsed as ArgoCdLocalConfig;
+
+  // Index servers and users by their key so contexts can be resolved to a base
+  // URL and token.
+  const serverByName = new Map<string, ArgoCdServer>();
+  for (const server of config.servers ?? []) {
+    if (server.server) serverByName.set(server.server, server);
+  }
+  const userByName = new Map<string, ArgoCdUser>();
+  for (const user of config.users ?? []) {
+    if (user.name) userByName.set(user.name, user);
+  }
+
+  const currentContext = config['current-context']?.trim() || undefined;
+  const entries: TokenRegistryEntry[] = [];
+  for (const context of config.contexts ?? []) {
+    const name = context.name?.trim();
+    const server = context.server?.trim();
+    if (!name || !server) continue;
+
+    const token = userByName.get(context.user ?? name)?.['auth-token']?.trim();
+    if (!token) {
+      // A context with no auth-token can't be used (e.g. never logged in, or an
+      // expired session). Skip it rather than fail the whole file, but say so.
+      logger.warn(`Skipping Argo CD context "${name}": no auth-token (run \`argocd login\`?)`);
+      continue;
+    }
+
+    const plainText = serverByName.get(server)?.['plain-text'] === true;
+    entries.push({
+      name,
+      baseUrl: toBaseUrl(server, plainText),
+      token,
+      default: name === currentContext
+    });
+  }
+  return { entries, currentContext };
+};
+
+// Read + parse the config file at `path` into a TokenRegistry. Throws (fails
+// closed) when the file is unreadable or malformed.
+const loadRegistryFromFile = (path: string): TokenRegistry => {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `Failed to read Argo CD config file at "${path}": ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  const { entries } = parseArgoCdLocalConfig(raw);
+  return new TokenRegistry(entries);
+};
+
+const pluralProfiles = (n: number): string => `${n} Argo CD profile${n === 1 ? '' : 's'}`;
+
+// Build a TokenRegistry from the Argo CD CLI config at `configPath`. When no
+// path is provided the registry is empty (the feature is opt-in: the default
+// `~/.config/argocd/config` location is never read implicitly). When a path IS
+// provided this fails closed — an unreadable or malformed file throws so the
+// process crashes at startup rather than silently running with no profiles.
+export const tokenRegistryFromArgoCdConfig = (
+  configPath: string | undefined = process.env.ARGOCD_CONFIG
+): TokenRegistry => {
+  const path = configPath?.trim();
+  if (!path) {
+    return new TokenRegistry();
+  }
+  const registry = loadRegistryFromFile(path);
+  logger.info(`Loaded ${pluralProfiles(registry.listProfiles().length)} from "${path}"`);
+  return registry;
+};
+
+// A live view over the profile registry. `get()` returns the currently loaded
+// registry (cheap, no I/O); `reload()` re-reads the Argo CD config file and
+// swaps in the refreshed registry, returning it.
+//
+// Reloading is opportunistic — the profile tools (list_profiles /
+// get_current_profile / set_profile) call reload() so that profiles added or
+// removed by `argocd login` / `argocd context` while the server is running are
+// picked up without a restart. Everything else reads the cached registry via
+// get(), so the hot path (resolving a client per tool call) does no file I/O.
+export type ProfileRegistrySource = {
+  get: () => TokenRegistry;
+  reload: () => TokenRegistry;
+};
+
+// Build a ProfileRegistrySource from the Argo CD CLI config at `configPath`.
+// When no path is given the source is a fixed empty registry. When a path is
+// given the initial load is eager so a missing or malformed file fails closed
+// at startup; a later reload() that fails (e.g. a partial write) is tolerated —
+// the last good registry is kept and a warning is logged.
+export const argoCdRegistrySource = (
+  configPath: string | undefined = process.env.ARGOCD_CONFIG
+): ProfileRegistrySource => {
+  const path = configPath?.trim();
+  if (!path) {
+    const empty = new TokenRegistry();
+    return { get: () => empty, reload: () => empty };
+  }
+
+  // Eager initial load — fail closed at startup, matching the previous behaviour.
+  let cached = loadRegistryFromFile(path);
+  logger.info(`Loaded ${pluralProfiles(cached.listProfiles().length)} from "${path}"`);
+
+  return {
+    get: () => cached,
+    reload: () => {
+      try {
+        cached = loadRegistryFromFile(path);
+      } catch (error) {
+        logger.warn(
+          `Failed to reload Argo CD config from "${path}", keeping previously loaded profiles: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+      return cached;
+    }
+  };
+};

--- a/src/cmd/cmd.ts
+++ b/src/cmd/cmd.ts
@@ -90,31 +90,49 @@ const start = (run: () => void) => {
   }
 };
 
+// Description shared by the --config option on every command. The path is
+// opt-in: the default ~/.config/argocd/config location is never read implicitly.
+const configOptionDescription =
+  'Path to an Argo CD CLI config file (the one written by `argocd login`/`argocd context`) to load instances as profiles. Defaults to the ARGOCD_CONFIG env var.';
+
 export const cmd = () => {
   const exe = yargs(hideBin(process.argv));
 
   exe.command(
     'stdio',
     'Start ArgoCD MCP server using stdio.',
-    () => {},
-    () => connectStdioTransport()
+    (yargs) => {
+      return yargs.option('config', { type: 'string', description: configOptionDescription });
+    },
+    ({ config }) => connectStdioTransport(config)
   );
 
-  exe.command('sse', 'Start ArgoCD MCP server using SSE.', listenerOptions, (argv) =>
-    start(() => connectSSETransport(transportOptions(argv)))
+  exe.command(
+    'sse',
+    'Start ArgoCD MCP server using SSE.',
+    (yargs) => listenerOptions(yargs).option('config', { type: 'string', description: configOptionDescription }),
+    (argv) => start(() => connectSSETransport({ ...transportOptions(argv), configPath: argv.config }))
   );
 
   exe.command(
     'http',
     'Start ArgoCD MCP server using Http Stream.',
     (yargs) =>
-      listenerOptions(yargs).option('stateless', {
-        type: 'boolean',
-        default: false,
-        description: 'Run in stateless mode'
-      }),
+      listenerOptions(yargs)
+        .option('stateless', {
+          type: 'boolean',
+          default: false,
+          description: 'Run in stateless mode'
+        })
+        .option('config', { type: 'string', description: configOptionDescription }),
     (argv) =>
-      start(() => connectHttpTransport({ ...transportOptions(argv), stateless: argv.stateless }))
+      start(() =>
+        connectHttpTransport({
+          ...transportOptions(argv),
+          stateless: argv.stateless,
+          configPath: argv.config
+        })
+      )
   );
 
   // Without strict(), a misspelled security flag ('--allowed-host') is silently

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -175,3 +175,152 @@ test('with no default token, an overridden URL still resolves only from the regi
   assert.equal(result.isError, true);
   assert.match(textOf(result), /Missing required ArgoCD API token/);
 });
+
+// --- Profile (context) selector tools ------------------------------------
+
+// Parse a tool's JSON result payload (the tools serialize their return value as
+// a single JSON text block).
+const jsonOf = (result: { content: { text: string }[] }): Record<string, unknown> =>
+  JSON.parse(textOf(result));
+
+test('list_profiles returns names + baseUrls (no token) and the active/default profile', async () => {
+  const registry = new TokenRegistry([
+    { name: 'prod', baseUrl: DEFAULT_BASE_URL, token: DEFAULT_TOKEN, default: true },
+    { name: 'other', baseUrl: OTHER_BASE_URL, token: 'super-secret-token' }
+  ]);
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: registry
+  });
+
+  const result = await callTool(server, 'list_profiles', {});
+  assert.equal(result.isError ?? false, false);
+  const text = textOf(result);
+  assert.ok(!text.includes('super-secret-token'));
+  assert.ok(!text.includes(DEFAULT_TOKEN));
+  const payload = jsonOf(result);
+  assert.deepEqual(payload.profiles, [
+    { name: 'prod', baseUrl: DEFAULT_BASE_URL },
+    { name: 'other', baseUrl: OTHER_BASE_URL }
+  ]);
+  assert.equal(payload.active, 'prod');
+  assert.equal(payload.default, 'prod');
+});
+
+test('list_profiles returns an empty list when no profiles are configured', async () => {
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry()
+  });
+
+  const payload = jsonOf(await callTool(server, 'list_profiles', {}));
+  assert.deepEqual(payload, { profiles: [], active: null, default: null });
+});
+
+test('get_current_profile reflects the registry default profile', async () => {
+  const registry = new TokenRegistry([
+    { name: 'prod', baseUrl: DEFAULT_BASE_URL, token: DEFAULT_TOKEN, default: true }
+  ]);
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: registry
+  });
+
+  const payload = jsonOf(await callTool(server, 'get_current_profile', {}));
+  assert.deepEqual(payload, { name: 'prod', baseUrl: DEFAULT_BASE_URL });
+});
+
+test('get_current_profile falls back to the default base URL when no profile is active', async () => {
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry()
+  });
+
+  const payload = jsonOf(await callTool(server, 'get_current_profile', {}));
+  assert.deepEqual(payload, { active: null, defaultBaseUrl: DEFAULT_BASE_URL });
+});
+
+test('set_profile to an unknown name returns an error', async () => {
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry()
+  });
+
+  const result = await callTool(server, 'set_profile', { name: 'nope' });
+  assert.equal(result.isError, true);
+  assert.match(textOf(result), /Unknown ArgoCD profile "nope"/);
+});
+
+test('set_profile switches the active profile so later calls target its instance with the registry token', async () => {
+  // 'other' points at a non-default host whose token comes ONLY from the
+  // registry. After selecting it, resolveClient must pair the other host with
+  // the registry token — never the default token (the exfiltration invariant).
+  const registry = new TokenRegistry([
+    { name: 'other', baseUrl: OTHER_BASE_URL, token: 'registered-token' }
+  ]);
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: registry
+  });
+
+  const setResult = await callTool(server, 'set_profile', { name: 'other' });
+  assert.equal(setResult.isError ?? false, false);
+  assert.deepEqual(jsonOf(setResult), { profile: { name: 'other', baseUrl: OTHER_BASE_URL } });
+
+  const client = (
+    server as unknown as {
+      resolveClient: (a: { argocdBaseUrl?: string }) => unknown;
+    }
+  ).resolveClient({}) as { client: { apiToken: string; baseUrl: string } };
+
+  assert.equal(client.client.baseUrl, OTHER_BASE_URL);
+  assert.equal(client.client.apiToken, 'registered-token');
+  assert.notEqual(client.client.apiToken, DEFAULT_TOKEN);
+});
+
+test('selecting a profile on a non-default host never borrows the default token', async () => {
+  // A profile whose host is NOT registered with a token must fail to resolve a
+  // token rather than fall back to the default token. We simulate this by
+  // pointing the active profile at the default host's neighbor via a registry
+  // entry that exists for routing but whose host differs from the default.
+  // Here the only profile lives on OTHER_BASE_URL with its own token, and we
+  // additionally prove that a tool call to a *different* unregistered host
+  // (EVIL) is still rejected even while a profile is active.
+  const registry = new TokenRegistry([
+    { name: 'other', baseUrl: OTHER_BASE_URL, token: 'registered-token' }
+  ]);
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: registry
+  });
+
+  await callTool(server, 'set_profile', { name: 'other' });
+  // Explicit per-call override still wins and is still subject to the token
+  // boundary: EVIL is unregistered, so no token resolves and no request is sent.
+  const result = await callTool(server, 'list_applications', { argocdBaseUrl: EVIL_BASE_URL });
+  assert.equal(result.isError, true);
+  assert.match(textOf(result), /Missing required ArgoCD API token/);
+});
+
+test('set_profile warns that the change does not persist in stateless mode', async () => {
+  const registry = new TokenRegistry([
+    { name: 'prod', baseUrl: DEFAULT_BASE_URL, token: DEFAULT_TOKEN }
+  ]);
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: registry,
+    stateless: true
+  });
+
+  const payload = jsonOf(await callTool(server, 'set_profile', { name: 'prod' }));
+  assert.deepEqual(payload.profile, { name: 'prod', baseUrl: DEFAULT_BASE_URL });
+  assert.match(String(payload.warning), /does not persist|stateless/i);
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,14 +9,24 @@ import {
   ApplicationSchema,
   ResourceRefSchema
 } from '../shared/models/schema.js';
-import { TokenRegistry, tokenRegistryFromEnv } from './tokenRegistry.js';
+import { TokenRegistry } from './tokenRegistry.js';
+import type { ProfileRegistrySource } from '../argocd/localConfig.js';
 
 type ServerInfo = {
   argocdBaseUrl: string;
   argocdApiToken: string;
-  // Optional registry mapping additional ArgoCD base URLs to their tokens. When
-  // omitted, it is loaded from the ARGOCD_TOKEN_REGISTRY_PATH env var.
+  // Registry of profiles + per-base-URL tokens, built from the user's Argo CD
+  // CLI config (see argocd/localConfig.ts). Defaults to an empty registry.
   tokenRegistry?: TokenRegistry;
+  // A live source for the registry that re-reads the config file on demand, so
+  // profiles added while the server runs are picked up. When omitted, the
+  // static tokenRegistry above is used (it never reloads). Takes precedence over
+  // tokenRegistry when both are given.
+  registrySource?: ProfileRegistrySource;
+  // Whether the server is running on the stateless HTTP transport, where a
+  // fresh Server is built per request. Used to warn that set_profile changes do
+  // not persist across requests in that mode.
+  stateless?: boolean;
 };
 
 // Per-call argument that any tool may accept to target a specific ArgoCD
@@ -43,12 +53,17 @@ type ArgoCDArgs = {
 export class Server extends McpServer {
   private defaultBaseUrl: string;
   private defaultApiToken: string;
-  private tokenRegistry: TokenRegistry;
+  private registrySource: ProfileRegistrySource;
   private argocdClient: ArgoCDClient;
   // Cache per-credential clients to avoid rebuilding the HttpClient on every
   // call. Keyed by baseUrl + token, since the same base URL may resolve to
   // different tokens (request token vs. registry token vs. default).
   private clientCache = new Map<string, ArgoCDClient>();
+  // The profile selected for this session (via set_profile, or the registry's
+  // default profile at startup). When set, tool calls that don't override the
+  // base URL target this profile's instance. Profile names are non-secret.
+  private activeProfileName?: string;
+  private stateless: boolean;
 
   constructor(serverInfo: ServerInfo) {
     super({
@@ -57,8 +72,15 @@ export class Server extends McpServer {
     });
     this.defaultBaseUrl = serverInfo.argocdBaseUrl;
     this.defaultApiToken = serverInfo.argocdApiToken;
-    this.tokenRegistry = serverInfo.tokenRegistry ?? tokenRegistryFromEnv();
+    const staticRegistry = serverInfo.tokenRegistry ?? new TokenRegistry();
+    this.registrySource = serverInfo.registrySource ?? {
+      get: () => staticRegistry,
+      reload: () => staticRegistry
+    };
     this.argocdClient = new ArgoCDClient(serverInfo.argocdBaseUrl, serverInfo.argocdApiToken);
+    this.stateless = serverInfo.stateless ?? false;
+    // Start on the registry's default profile, if one is configured.
+    this.activeProfileName = this.registrySource.get().getDefaultProfileName();
 
     const isReadOnly =
       String(process.env.MCP_READ_ONLY ?? '')
@@ -274,6 +296,66 @@ export class Server extends McpServer {
         )
     );
 
+    // Profile (context) selector tools. These operate on registry/session
+    // metadata, not on a remote ArgoCD instance, so they are always available
+    // (including in read-only mode) and never resolve an ArgoCD client. Tokens
+    // are never exposed by any of them.
+    this.addMetaTool(
+      'list_profiles',
+      'list_profiles returns the configured ArgoCD profiles (named instances) as { name, baseUrl } objects, along with which profile is currently active and which is the default. Tokens are never included. Use set_profile to switch the active profile.',
+      {},
+      () => {
+        // Opportunistically re-read the config so profiles added since startup
+        // (e.g. via `argocd login`) show up without restarting the server.
+        const registry = this.registrySource.reload();
+        return {
+          profiles: registry.listProfiles(),
+          active: this.activeProfileName ?? null,
+          default: registry.getDefaultProfileName() ?? null
+        };
+      }
+    );
+    this.addMetaTool(
+      'get_current_profile',
+      'get_current_profile returns the profile currently active for this session as { name, baseUrl }. When no profile is active, returns the default base URL that calls target instead.',
+      {},
+      () => {
+        const registry = this.registrySource.reload();
+        const profile = this.activeProfileName
+          ? registry.getProfile(this.activeProfileName)
+          : undefined;
+        if (profile) return profile;
+        return { active: null, defaultBaseUrl: this.defaultBaseUrl || null };
+      }
+    );
+    this.addMetaTool(
+      'set_profile',
+      "set_profile selects the active ArgoCD profile for this session by name. Subsequent tool calls that do not override the base URL will target the selected profile's instance. Use list_profiles to see available names.",
+      {
+        name: z
+          .string()
+          .describe(
+            'Name of the profile to activate. Must match a configured profile (see list_profiles).'
+          )
+      },
+      ({ name }) => {
+        // Reload first so a profile added since startup can be selected.
+        const profile = this.registrySource.reload().getProfile(name);
+        if (!profile) {
+          throw new Error(
+            `Unknown ArgoCD profile "${name}". Use list_profiles to see available profiles.`
+          );
+        }
+        this.activeProfileName = profile.name;
+        const result: { profile: typeof profile; warning?: string } = { profile };
+        if (this.stateless) {
+          result.warning =
+            'Profile set for this request only; in stateless HTTP mode session state does not persist across requests. Configure a default profile in the token registry instead.';
+        }
+        return result;
+      }
+    );
+
     // Only register modification tools if not in read-only mode
     if (!isReadOnly) {
       this.addJsonOutputTool(
@@ -396,8 +478,34 @@ export class Server extends McpServer {
   // This lets a single server target multiple ArgoCD instances, each with its
   // own token, without the token ever appearing in a tool-call payload: callers
   // pass only the (non-secret) base URL and the server pairs it with the token.
+  // Resolve the effective base URL for a call. Precedence:
+  //   1. the per-call argocdBaseUrl argument (most explicit);
+  //   2. the session's active profile (set via set_profile or the registry
+  //      default), resolved to its base URL;
+  //   3. the session default base URL.
+  // The token-selection logic in resolveClient below is intentionally left
+  // unchanged: a profile simply yields a base URL, which then resolves its
+  // token through the same registry/default rules, preserving the invariant
+  // that the default token is only ever sent to the default base URL.
+  private resolveBaseUrl(args: ArgoCDArgs, registry: TokenRegistry): string {
+    if (args.argocdBaseUrl) return args.argocdBaseUrl;
+    if (this.activeProfileName) {
+      const profile = registry.getProfile(this.activeProfileName);
+      if (!profile) {
+        throw new Error(
+          `Unknown ArgoCD profile "${this.activeProfileName}". Use list_profiles to see available profiles.`
+        );
+      }
+      return profile.baseUrl;
+    }
+    return this.defaultBaseUrl;
+  }
+
   private resolveClient(args: ArgoCDArgs): ArgoCDClient {
-    const baseUrl = args.argocdBaseUrl || this.defaultBaseUrl;
+    // Read the currently loaded registry once (no file I/O); the profile tools
+    // are what refresh it from disk.
+    const registry = this.registrySource.get();
+    const baseUrl = this.resolveBaseUrl(args, registry);
 
     // The base URL is optional at the session level; when no default is
     // configured, the caller must supply the argocdBaseUrl argument.
@@ -418,8 +526,8 @@ export class Server extends McpServer {
     const isDefaultBaseUrl =
       TokenRegistry.normalize(baseUrl) === TokenRegistry.normalize(this.defaultBaseUrl);
     const apiToken = isDefaultBaseUrl
-      ? this.defaultApiToken || this.tokenRegistry.getToken(baseUrl)
-      : this.tokenRegistry.getToken(baseUrl);
+      ? this.defaultApiToken || registry.getToken(baseUrl)
+      : registry.getToken(baseUrl);
 
     if (!apiToken) {
       throw new Error(
@@ -471,6 +579,33 @@ export class Server extends McpServer {
           client,
           extra
         );
+        return {
+          isError: false,
+          content: [{ type: 'text', text: JSON.stringify(result) }]
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }]
+        };
+      }
+    });
+  }
+
+  // Register a tool that operates on registry/session metadata rather than a
+  // remote ArgoCD instance. Unlike addJsonOutputTool it does NOT merge the
+  // argocdBaseUrl argument or resolve an ArgoCD client; it just wraps the
+  // callback's return value in the standard JSON result/error envelope.
+  private addMetaTool<Args extends ZodRawShape, T>(
+    name: string,
+    description: string,
+    paramsSchema: Args,
+    cb: (cbArgs: Parameters<ToolCallback<Args>>[0]) => T
+  ) {
+    this.tool(name, description, paramsSchema, async (...args) => {
+      try {
+        const [allArgs] = args as [Parameters<ToolCallback<Args>>[0]];
+        const result = cb.call(this, allArgs);
         return {
           isError: false,
           content: [{ type: 'text', text: JSON.stringify(result) }]

--- a/src/server/tokenRegistry.test.ts
+++ b/src/server/tokenRegistry.test.ts
@@ -1,18 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { TokenRegistry, parseTokenRegistry, tokenRegistryFromEnv } from './tokenRegistry.js';
-
-// Helper: write `contents` to a throwaway file and return its path. The file is
-// removed when `cleanup` is called, keeping each test self-contained.
-const withTempFile = (contents: string): { path: string; cleanup: () => void } => {
-  const dir = mkdtempSync(join(tmpdir(), 'token-registry-test-'));
-  const path = join(dir, 'registry.json');
-  writeFileSync(path, contents, 'utf8');
-  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
-};
+import { TokenRegistry } from './tokenRegistry.js';
 
 // --- TokenRegistry construction & lookup ---------------------------------
 
@@ -72,63 +60,82 @@ test('constructor error does not leak the token value', () => {
   );
 });
 
-// --- parseTokenRegistry --------------------------------------------------
+// --- Profiles ------------------------------------------------------------
 
-test('parseTokenRegistry builds a registry from a valid JSON array', () => {
-  const registry = parseTokenRegistry(
-    JSON.stringify([
-      { baseUrl: 'https://argo-a.example.com', token: 'token-a' },
-      { baseUrl: 'https://argo-b.example.com', token: 'token-b' }
-    ])
-  );
-  assert.equal(registry.getSize(), 2);
-  assert.equal(registry.getToken('https://argo-b.example.com'), 'token-b');
+test('entries without a name contribute no profiles (backward compatible)', () => {
+  const registry = new TokenRegistry([
+    { baseUrl: 'https://argo-a.example.com', token: 'token-a' },
+    { baseUrl: 'https://argo-b.example.com', token: 'token-b' }
+  ]);
+  assert.deepEqual(registry.listProfiles(), []);
+  assert.equal(registry.getSize(), 2); // still routable by base URL
+  assert.equal(registry.getDefaultProfileName(), undefined);
 });
 
-test('parseTokenRegistry throws on invalid JSON', () => {
-  assert.throws(() => parseTokenRegistry('not json {'), /not valid JSON/);
+test('named entries become selectable profiles exposing name + baseUrl only', () => {
+  const registry = new TokenRegistry([
+    { name: 'prod', baseUrl: 'https://argo-a.example.com', token: 'token-a' },
+    { name: 'staging', baseUrl: 'https://argo-b.example.com', token: 'token-b' }
+  ]);
+  assert.deepEqual(registry.listProfiles(), [
+    { name: 'prod', baseUrl: 'https://argo-a.example.com' },
+    { name: 'staging', baseUrl: 'https://argo-b.example.com' }
+  ]);
 });
 
-test('parseTokenRegistry throws when the JSON is not an array', () => {
+test('listProfiles never exposes tokens', () => {
+  const registry = new TokenRegistry([
+    { name: 'prod', baseUrl: 'https://argo-a.example.com', token: 'super-secret-token' }
+  ]);
+  assert.ok(!JSON.stringify(registry.listProfiles()).includes('super-secret-token'));
+});
+
+test('getProfile resolves names case-insensitively', () => {
+  const registry = new TokenRegistry([
+    { name: 'Prod', baseUrl: 'https://argo-a.example.com', token: 'token-a' }
+  ]);
+  assert.deepEqual(registry.getProfile('prod'), {
+    name: 'Prod',
+    baseUrl: 'https://argo-a.example.com'
+  });
+  assert.deepEqual(registry.getProfile('PROD'), {
+    name: 'Prod',
+    baseUrl: 'https://argo-a.example.com'
+  });
+  assert.equal(registry.getProfile('missing'), undefined);
+});
+
+test('a single default: true entry sets the default profile name', () => {
+  const registry = new TokenRegistry([
+    { name: 'prod', baseUrl: 'https://argo-a.example.com', token: 'token-a' },
+    { name: 'staging', baseUrl: 'https://argo-b.example.com', token: 'token-b', default: true }
+  ]);
+  assert.equal(registry.getDefaultProfileName(), 'staging');
+});
+
+test('constructor throws (fail closed) on duplicate profile names without leaking the token', () => {
   assert.throws(
-    () => parseTokenRegistry(JSON.stringify({ baseUrl: 'x', token: 'y' })),
-    /must contain a JSON array/
+    () =>
+      new TokenRegistry([
+        { name: 'prod', baseUrl: 'https://argo-a.example.com', token: 'super-secret-token' },
+        { name: 'PROD', baseUrl: 'https://argo-b.example.com', token: 'token-b' }
+      ]),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /duplicate profile name/);
+      assert.ok(!error.message.includes('super-secret-token'));
+      return true;
+    }
   );
 });
 
-// --- tokenRegistryFromEnv ------------------------------------------------
-
-test('tokenRegistryFromEnv returns an empty registry when the path is unset', () => {
-  assert.equal(tokenRegistryFromEnv(undefined).getSize(), 0);
-  assert.equal(tokenRegistryFromEnv('').getSize(), 0);
-  assert.equal(tokenRegistryFromEnv('   ').getSize(), 0);
-});
-
-test('tokenRegistryFromEnv loads a registry from a valid file', () => {
-  const { path, cleanup } = withTempFile(
-    JSON.stringify([{ baseUrl: 'https://argo-a.example.com', token: 'token-a' }])
-  );
-  try {
-    const registry = tokenRegistryFromEnv(path);
-    assert.equal(registry.getSize(), 1);
-    assert.equal(registry.getToken('https://argo-a.example.com'), 'token-a');
-  } finally {
-    cleanup();
-  }
-});
-
-test('tokenRegistryFromEnv throws (fail closed) when the configured file is missing', () => {
+test('constructor throws (fail closed) when more than one profile is default', () => {
   assert.throws(
-    () => tokenRegistryFromEnv('/nonexistent/path/registry.json'),
-    /Failed to read ArgoCD token registry file/
+    () =>
+      new TokenRegistry([
+        { name: 'prod', baseUrl: 'https://argo-a.example.com', token: 'token-a', default: true },
+        { name: 'staging', baseUrl: 'https://argo-b.example.com', token: 'token-b', default: true }
+      ]),
+    /more than one default profile/
   );
-});
-
-test('tokenRegistryFromEnv throws (fail closed) when the configured file is malformed', () => {
-  const { path, cleanup } = withTempFile('not json {');
-  try {
-    assert.throws(() => tokenRegistryFromEnv(path), /not valid JSON/);
-  } finally {
-    cleanup();
-  }
 });

--- a/src/server/tokenRegistry.ts
+++ b/src/server/tokenRegistry.ts
@@ -1,34 +1,47 @@
-import { readFileSync } from 'node:fs';
-import { logger } from '../logging/logging.js';
-
-// A read-only registry that maps an ArgoCD base URL to the API token that
-// should be used for it. It lets a single server target multiple ArgoCD
-// instances — each with its own token — without the token ever being passed in
-// a tool-call payload: the caller supplies only the (non-secret) base URL and
+// A read-only in-memory registry that maps an ArgoCD base URL to the API token
+// that should be used for it, and an optional profile name to that base URL. It
+// lets a single server target multiple ArgoCD instances — each with its own
+// token — without the token ever being passed in a tool-call payload: the
+// caller selects an instance by its (non-secret) profile name or base URL and
 // the server pairs it with the configured token.
 //
-// Configuration source: a JSON file whose path is given by the
-// ARGOCD_TOKEN_REGISTRY_PATH environment variable. The tokens are secrets, so
-// they are read from a file (e.g. a mounted Kubernetes secret) rather than an
-// env var, keeping them out of the process environment, crash dumps, and child
-// process inheritance. The file contains a JSON array of { baseUrl, token }
-// entries, e.g.
-//
-//   [
-//     {"baseUrl":"https://argo-a.example.com","token":"<token-a>"},
-//     {"baseUrl":"https://argo-b.example.com","token":"<token-b>"}
-//   ]
+// The registry is populated from the user's Argo CD CLI config file (see
+// argocd/localConfig.ts), so the credentials obtained via `argocd login`
+// (including SSO/OIDC and LDAP tokens) are reused directly. Tokens stay in this
+// in-memory store and are never exposed by the profile tools or tool-call
+// payloads.
 //
 // Base URLs are normalized (lowercased host, trailing slashes stripped) so
 // trivial formatting differences between the configured value and the requested
 // value don't cause a lookup miss.
+//
+// An entry may carry a non-secret `name`, which turns it into a selectable
+// "profile" (a friendly alias for the base URL — see Profile below), and an
+// optional `default: true` marking the profile that is active when a session
+// starts. Entries without a name still route by base URL; they just don't
+// appear in the profile list.
 export type TokenRegistryEntry = {
   baseUrl: string;
   token: string;
+  name?: string;
+  default?: boolean;
+};
+
+// The non-secret projection of a registry entry. A profile is a friendly,
+// named alias for a base URL that callers can select without ever seeing — or
+// needing to know — the token. The token is deliberately absent here so it can
+// never leak through a profile-listing tool's output.
+export type Profile = {
+  name: string;
+  baseUrl: string;
 };
 
 export class TokenRegistry {
   private tokensByBaseUrl = new Map<string, string>();
+  // Profiles keyed by their normalized (lowercased, trimmed) name. The stored
+  // Profile keeps the original-cased name and base URL for display.
+  private profilesByName = new Map<string, Profile>();
+  private defaultProfileName?: string;
 
   constructor(entries: TokenRegistryEntry[] = []) {
     for (const entry of entries) {
@@ -38,6 +51,28 @@ export class TokenRegistry {
         throw new Error('ArgoCD token registry entry is missing baseUrl or token');
       }
       this.tokensByBaseUrl.set(TokenRegistry.normalize(entry.baseUrl), entry.token);
+
+      const name = entry.name?.trim();
+      if (!name) {
+        // Unnamed entry: usable for base-URL routing, but not a selectable
+        // profile. Skip the profile bookkeeping (including any `default` flag,
+        // which is meaningless without a name to select).
+        continue;
+      }
+      const key = TokenRegistry.normalizeName(name);
+      if (this.profilesByName.has(key)) {
+        // Fail closed: duplicate names make selection ambiguous. Don't leak the
+        // token in the error.
+        throw new Error(`ArgoCD token registry has duplicate profile name "${name}"`);
+      }
+      this.profilesByName.set(key, { name, baseUrl: entry.baseUrl });
+      if (entry.default) {
+        if (this.defaultProfileName) {
+          // Fail closed: more than one default is ambiguous.
+          throw new Error('ArgoCD token registry has more than one default profile');
+        }
+        this.defaultProfileName = name;
+      }
     }
   }
 
@@ -50,6 +85,25 @@ export class TokenRegistry {
 
   public getSize(): number {
     return this.tokensByBaseUrl.size;
+  }
+
+  // Returns the profile with the given name (case-insensitive), or undefined
+  // when no such profile is registered.
+  public getProfile(name: string): Profile | undefined {
+    if (!name) return undefined;
+    return this.profilesByName.get(TokenRegistry.normalizeName(name));
+  }
+
+  // Returns all configured profiles as non-secret { name, baseUrl } objects.
+  // Never includes tokens.
+  public listProfiles(): Profile[] {
+    return [...this.profilesByName.values()].map((p) => ({ name: p.name, baseUrl: p.baseUrl }));
+  }
+
+  // Returns the name of the profile marked `default: true`, or undefined when
+  // none is.
+  public getDefaultProfileName(): string | undefined {
+    return this.defaultProfileName;
   }
 
   // Normalize a base URL for stable lookups: lowercase the scheme+host and drop
@@ -67,52 +121,11 @@ export class TokenRegistry {
       return trimmed.replace(/\/+$/, '');
     }
   }
+
+  // Normalize a profile name for stable, case-insensitive lookups. Mirrors the
+  // base-URL normalization spirit so "Staging" and "staging" select the same
+  // profile.
+  public static normalizeName(name: string): string {
+    return name.trim().toLowerCase();
+  }
 }
-
-// Parse the raw JSON contents of a token registry file into a TokenRegistry.
-// Throws when the contents are not valid JSON or not a JSON array: an operator
-// who configured a registry file expects token routing, so a malformed file is
-// a misconfiguration we surface loudly rather than silently degrade.
-export const parseTokenRegistry = (raw: string): TokenRegistry => {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    throw new Error(
-      `ArgoCD token registry file is not valid JSON: ${error instanceof Error ? error.message : String(error)}`
-    );
-  }
-  if (!Array.isArray(parsed)) {
-    throw new Error('ArgoCD token registry file must contain a JSON array');
-  }
-  return new TokenRegistry(parsed as TokenRegistryEntry[]);
-};
-
-// Build a TokenRegistry from the JSON file at ARGOCD_TOKEN_REGISTRY_PATH.
-// Returns an empty registry when the variable is unset (the server then runs on
-// its single default credential). When the variable IS set, this fails closed:
-// if the file cannot be read or is malformed it throws, so the process crashes
-// at startup rather than silently falling back to the default credential — which
-// could route calls to an instance with the wrong token.
-export const tokenRegistryFromEnv = (
-  registryPath: string | undefined = process.env.ARGOCD_TOKEN_REGISTRY_PATH
-): TokenRegistry => {
-  if (!registryPath || !registryPath.trim()) {
-    return new TokenRegistry();
-  }
-  let raw: string;
-  try {
-    raw = readFileSync(registryPath.trim(), 'utf8');
-  } catch (error) {
-    throw new Error(
-      `Failed to read ArgoCD token registry file at "${registryPath}": ${error instanceof Error ? error.message : String(error)}`
-    );
-  }
-  const registry = parseTokenRegistry(raw);
-  logger.info(
-    `Loaded ArgoCD token registry from "${registryPath}" with ${registry.getSize()} entr${
-      registry.getSize() === 1 ? 'y' : 'ies'
-    }`
-  );
-  return registry;
-};

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -7,23 +7,26 @@ import { randomUUID } from 'node:crypto';
 import type { AddressInfo } from 'node:net';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { tokenRegistryFromEnv } from './tokenRegistry.js';
+import { argoCdRegistrySource, type ProfileRegistrySource } from '../argocd/localConfig.js';
 import {
   applyListenerSecurity,
   resolveListenerSecurity,
   type ListenerSecurityOptions
 } from './security.js';
 
-// Load the base-URL -> token registry once at startup from the JSON file at
-// ARGOCD_TOKEN_REGISTRY_PATH. Shared across all connections; read-only after
-// construction.
-const tokenRegistry = tokenRegistryFromEnv();
+// Build the profile registry source once at startup from the Argo CD CLI config
+// file. The path is opt-in (the --config flag or the ARGOCD_CONFIG env var); the
+// default ~/.config/argocd/config location is never read implicitly. The initial
+// load is eager (fails closed); the profile tools re-read it on demand. Shared
+// across all connections.
+const buildRegistrySource = (configPath?: string) =>
+  argoCdRegistrySource(configPath ?? process.env.ARGOCD_CONFIG);
 
-export const connectStdioTransport = () => {
+export const connectStdioTransport = (configPath?: string) => {
   const server = createServer({
     argocdBaseUrl: process.env.ARGOCD_BASE_URL || '',
     argocdApiToken: process.env.ARGOCD_API_TOKEN || '',
-    tokenRegistry
+    registrySource: buildRegistrySource(configPath)
   });
 
   logger.info('Connecting to stdio transport');
@@ -64,9 +67,9 @@ const listen = (app: express.Express, bindAddress: string, port: number, label: 
 // stays in the transport layer and out of prompts/model context.
 //
 // The token is normally MANDATORY and the connection is rejected when it is
-// missing. The exception is when a token registry (ARGOCD_TOKEN_REGISTRY_PATH)
-// is configured: the per-call base URL can then resolve its token from the
-// registry, so a tokenless connection is allowed.
+// missing. The exception is when profiles (loaded from the Argo CD CLI config
+// via --config / ARGOCD_CONFIG) are configured: the per-call base URL can then
+// resolve its token from the registry, so a tokenless connection is allowed.
 //
 // The base URL is optional at this level: when it is absent, callers may supply
 // it per call via the argocdBaseUrl tool argument.
@@ -75,39 +78,41 @@ const listen = (app: express.Express, bindAddress: string, port: number, label: 
 // job (MCP_AUTH_TOKEN, see security.ts).
 const resolveCredentials = (
   req: express.Request,
-  res: express.Response
+  res: express.Response,
+  registrySource: ProfileRegistrySource
 ): { argocdBaseUrl: string; argocdApiToken: string } | null => {
   const argocdBaseUrl =
     (req.headers['x-argocd-base-url'] as string) || process.env.ARGOCD_BASE_URL || '';
   const argocdApiToken =
     (req.headers['x-argocd-api-token'] as string) || process.env.ARGOCD_API_TOKEN || '';
-  if (!argocdApiToken && tokenRegistry.getSize() === 0) {
+  if (!argocdApiToken && registrySource.get().getSize() === 0) {
     res
       .status(400)
       .send(
         'x-argocd-api-token must be provided in the request header (or the ARGOCD_API_TOKEN env var), ' +
-          'or a token registry must be configured via ARGOCD_TOKEN_REGISTRY_PATH.'
+          'or Argo CD profiles must be configured via --config / ARGOCD_CONFIG.'
       );
     return null;
   }
   return { argocdBaseUrl, argocdApiToken };
 };
 
-export const connectSSETransport = (options: TransportOptions) => {
+export const connectSSETransport = (options: TransportOptions & { configPath?: string }) => {
   const security = resolveListenerSecurity(options);
-  const { port } = options;
+  const { port, configPath } = options;
   const app = express();
   registerHealthz(app);
   applyListenerSecurity(app, security);
   const transports: { [sessionId: string]: SSEServerTransport } = {};
+  const registrySource = buildRegistrySource(configPath);
 
   app.get('/sse', async (req, res) => {
     // Same credential requirement as the http transport. Without it the handler
     // built an McpServer with empty credentials and held it until the socket
     // closed, one per connection.
-    const credentials = resolveCredentials(req, res);
+    const credentials = resolveCredentials(req, res, registrySource);
     if (!credentials) return;
-    const server = createServer({ ...credentials, tokenRegistry });
+    const server = createServer({ ...credentials, registrySource });
 
     const transport = new SSEServerTransport('/messages', res);
     transports[transport.sessionId] = transport;
@@ -130,15 +135,18 @@ export const connectSSETransport = (options: TransportOptions) => {
   return listen(app, security.bindAddress, port, 'SSE transport');
 };
 
-export const connectHttpTransport = (options: TransportOptions & { stateless?: boolean }) => {
+export const connectHttpTransport = (
+  options: TransportOptions & { stateless?: boolean; configPath?: string }
+) => {
   const security = resolveListenerSecurity(options);
-  const { port, stateless = false } = options;
+  const { port, stateless = false, configPath } = options;
   const app = express();
   registerHealthz(app);
   applyListenerSecurity(app, security);
   // After the security middleware, so malformed JSON returns 401/403 rather than
   // the body parser's 400, which would tell a caller it passed the credential check.
   app.use(express.json());
+  const registrySource = buildRegistrySource(configPath);
 
   const httpTransports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
 
@@ -149,7 +157,7 @@ export const connectHttpTransport = (options: TransportOptions & { stateless?: b
     if (!stateless && sessionIdFromHeader && httpTransports[sessionIdFromHeader]) {
       transport = httpTransports[sessionIdFromHeader];
     } else if (stateless || (!sessionIdFromHeader && isInitializeRequest(req.body))) {
-      const credentials = resolveCredentials(req, res);
+      const credentials = resolveCredentials(req, res, registrySource);
       if (!credentials) return;
 
       transport = new StreamableHTTPServerTransport(
@@ -169,7 +177,7 @@ export const connectHttpTransport = (options: TransportOptions & { stateless?: b
         };
       }
 
-      const server = createServer({ ...credentials, tokenRegistry });
+      const server = createServer({ ...credentials, registrySource, stateless });
       await server.connect(transport);
     } else {
       const errorMsg = sessionIdFromHeader


### PR DESCRIPTION
Improvement based on https://github.com/argoproj-labs/mcp-for-argocd/issues/126

We can use ArgoCD CLI to manage configuration profiles similar to kubectl contexts. The ArgoCD CLI configuration file has already all required information for the MCP server to use. Here is an example:

```yaml
contexts:
- name: argocd-context-name-a
  server: argocd-server-name-a
  user: argocd-user-name-a
- name: argocd-context-name-b
  server: argocd-server-name-b
  user: argocd-user-name-b
current-context: argocd-context-name-a
prompts-enabled: false
servers:
- grpc-web: true
  grpc-web-root-path: ""
  server: argocd-server-name-a
- grpc-web: true
  grpc-web-root-path: ""
  server: argocd-server-name-b
users:
- auth-token: raw-auth-token
  name: argocd-user-name-a
  refresh-token: raw-refresh-token
- auth-token: raw-auth-token
  name: argocd-user-name-b
  refresh-token: raw-refresh-token

```

ArgoCD CLI can use these profiles via the `--argocd-context` CLI parameter, so can the MCP server too. Three newly added MCP commands will be able to accomplish this task. As a result, LLM will be able to seamlessly switch between profiles without handling credentials within its context. These commands are:
- `list_profiles`
- `set_profile`
- `get_current_profile`

To test locally:

1. Authenticate to ArgoCD server of choice via the ArgoCD CLI: `argocd login argocd-server-name-a --sso --grpc-web --name argocd-context-name-a`
2. Optionally, switch context: `argocd context argocd-context-name-a`
3. Clone repo, switch to feature branch
3. Test: `corepack pnpm test`
4. Lint: `corepack pnpm run lint`
5. Build: `corepack pnpm run build`
6. Configure MCP server

```json
{
  "mcpServers": {
    "argocd": {
      "command": "node",
      "args": [
        "/Users/user/projects/mcp-for-argocd/dist/index.js",
        "stdio",
        "--config",
        "/Users/user/.config/argocd/config"
      ],
      "env": {
        "MCP_READ_ONLY": "true"
      }
    }
  }
}
```

Or:

```terminal
$ npx @modelcontextprotocol/inspector \
  -e ARGOCD_CONFIG=$HOME/.config/argocd/config \
  -e MCP_READ_ONLY=true node dist/index.js stdio
```

```terminal
$ npx @modelcontextprotocol/inspector \
  --cli \
  -e ARGOCD_CONFIG=$HOME/.config/argocd/config \
  node dist/index.js stdio --method tools/call --tool-name list_profiles
```
