### PR TITLE
docs: fix stateless Docker command (Cannot find module '/app/http')

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,12 +263,21 @@ To run without session affinity requirements, start the server with the `--state
 node dist/index.js http --stateless
 ```
 
-Or with Docker:
+Or with Docker. The published image provides the server command through `CMD`
+(`node dist/index.js http`) on top of the Node base image's generic entrypoint, so any
+arguments you pass to `docker run` **replace** that command rather than appending to it.
+Pass the full command — including `node dist/index.js` — alongside the flags:
 
 ```bash
 docker run -e ARGOCD_BASE_URL=<argocd_url> -e ARGOCD_API_TOKEN=<argocd_token> \
-  argoprojlabs/mcp-for-argocd http --stateless
+  ghcr.io/argoproj-labs/mcp-for-argocd node dist/index.js http --stateless
 ```
+
+> **Why the full command?** The image has no app-specific `ENTRYPOINT`. Running
+> `docker run ... ghcr.io/argoproj-labs/mcp-for-argocd http --stateless` makes the base
+> image's launcher treat `http` as a script path and fails with
+> `Error: Cannot find module '/app/http'`. Including `node dist/index.js` appends the
+> `http --stateless` flags to the real command.
 
 In stateless mode:
 - No `Mcp-Session-Id` is returned or required — any replica can handle any request


### PR DESCRIPTION
## What

Fixes the Stateless Mode Docker command in the README. As documented:

```bash
docker run ... argoprojlabs/mcp-for-argocd http --stateless
```

fails with `Error: Cannot find module '/app/http'` (exit 1).

## Why

The image defines no app-specific `ENTRYPOINT`; the server command is set via `CMD [ "node", "dist/index.js", "http" ]` on top of the Node base image's generic `docker-entrypoint.sh`. `docker run` arguments **replace** `CMD` rather than appending, so `http --stateless` is run as `node http --stateless` and Node fails to resolve `/app/http`.

## Change

- Document the full command: `... node dist/index.js http --stateless`, which appends the flags to the real entrypoint.
- Reference the `ghcr.io/argoproj-labs/mcp-for-argocd` image that CI actually publishes (the prior `argoprojlabs/mcp-for-argocd` resolves to Docker Hub).
- Add a short note explaining the entrypoint/CMD behavior so the fix is self-documenting.

Docs-only change.

## Verification

```console
# Before (as documented) — fails
$ docker run --rm ghcr.io/argoproj-labs/mcp-for-argocd:latest http --stateless
Error: Cannot find module '/app/http'   # exit 1

# After (this PR) — boots in stateless mode, /healthz => 200
$ docker run -d -p 3000:3000 ghcr.io/argoproj-labs/mcp-for-argocd:latest \
    node dist/index.js http --stateless
{"level":30,"msg":"Connecting to Http Stream transport on port: 3000 (stateless mode)"}
$ curl -s -o /dev/null -w '%{http_code}\n' localhost:3000/healthz
200
```

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)