### PR TITLE
feat: add JWT passthrough auth mode to token registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.git
+.github
+.vscode
+.cursor
+.claude
+*.log
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ ARGOCD_TOKEN_REGISTRY_PATH=/app/argocd-mcp/token-registry.json
 The file contains a JSON array of entries, each keyed by base URL. An entry authenticates its instance one of two ways — set **exactly one** of `token` or `passthrough`:
 
 - `token` — a **static token** configured for that instance. The token stays on the server; the caller only references the URL.
-- `passthrough: true` — **forward the caller's per-request token** (the `x-argocd-api-token` JWT) to that instance, so the end user's own identity reaches ArgoCD for auditability, with no per-instance token to mint. This only authenticates when the same token is accepted by the instance — i.e. a **shared OIDC/SSO** setup where one identity provider fronts every instance (an ArgoCD-local token or PAT is per-instance and will not authenticate elsewhere).
+- `passthrough: true` — **forward the caller's per-request token** (the `x-argocd-api-token` JWT) to that instance, so the end user's own identity reaches ArgoCD for auditability, with no per-instance token to mint. The forwarded token must be one the target instance accepts — i.e. an **OIDC/SSO** token whose audience matches that instance's OIDC client. The caller is responsible for presenting the token scoped to the instance it is targeting (see [Security & deployment requirements](#security--deployment-requirements-for-passthrough) below). An ArgoCD-local token or PAT is bound to a single instance and will not authenticate elsewhere.
 
 ```json
 [
@@ -194,6 +194,18 @@ The file contains a JSON array of entries, each keyed by base URL. An entry auth
 ```
 
 > **Passthrough needs matching RBAC.** A forwarded identity only succeeds if that user has the required permissions on the target instance; otherwise the call returns a per-instance `403` from ArgoCD (not a routing error). An entry that sets neither `token` nor `passthrough` — or both — is rejected at startup (fail closed), so a secret that fails to mount and leaves `token` blank crashes rather than silently forwarding the JWT.
+
+###### Security & deployment requirements for passthrough
+
+Passthrough forwards a bearer token to another host, so it has two hard requirements. Read these before enabling it.
+
+1. **Every passthrough instance MUST enforce OIDC audience validation.** When several ArgoCD instances share one identity provider (e.g. the same Okta org / auth server), they share an **issuer and signing keys** — so any instance can cryptographically *verify the signature* of a token issued for any other instance. The **only** thing that stops a token from one instance being replayed against another is the audience (`aud` / `client_id`) check. The safe configuration is **one OIDC client (app) per ArgoCD instance**, each validating its own audience: a token scoped to instance A is then rejected by instance B, so a forwarded (or leaked) token cannot be reused elsewhere. **Do not relax this** — if an instance enables `skipAudienceCheckWhenTokenHasEmptyAudience`, lists another instance's client ID in `allowedAudiences`, or two instances share a client ID, the audience wall is gone and a token forwarded to one instance becomes replayable against the others. Audience validation is the load-bearing control here, not network reachability.
+
+2. **Use stateless mode for multi-instance passthrough.** Because each instance validates its own audience, **one token authenticates to exactly one instance** — there is no single token that works everywhere. The caller must therefore attach the audience-scoped token for whichever instance it is targeting, on each request. That only works when the token is read per request:
+   - **`http --stateless`** (recommended for passthrough): the `x-argocd-api-token` header is read fresh on every call, so a caller can target different instances — each with its own token — across calls.
+   - **Default session mode / SSE:** the token is bound once at connection time, so a single session is effectively pinned to one instance's audience. Multi-instance use within one session will fail audience validation on the other instances.
+
+> **Trust note.** Static-token entries keep each instance's credential scoped to that instance alone. Passthrough instead forwards the caller's token; with per-instance audiences (requirement 1) its scope stays limited to the target instance, which is why that requirement is mandatory rather than optional.
 
 > **Secure the file.** Restrict it to the server's user (e.g. `chmod 400`) and prefer a secret-management mechanism (Kubernetes secret volume, Vault agent, etc.) over a plaintext file on disk.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The ArgoCD **API token is a secret and is only ever read from the transport laye
 - **HTTP headers** (HTTP transport only): `x-argocd-api-token`.
 - **Environment variables**: `ARGOCD_API_TOKEN` (all transports).
 
-This is the **default token**. It is **mandatory unless a [token registry](#token-registry--per-base-url-tokens-multi-instance) is configured**: on the HTTP transport, a connection that supplies no token (neither header nor env var) is rejected with `400 Bad Request`, but when a registry is configured a tokenless connection is allowed because each call resolves its own [registry token](#two-kinds-of-token). Keeping the token out of tool arguments ensures it never enters prompts, model context, or tool-call logs.
+This is the **default token**. It is **mandatory unless a [token registry](#token-registry--per-base-url-tokens-multi-instance) is configured**: on the HTTP transport, a connection that supplies no token (neither header nor env var) is rejected with `400 Bad Request`, but when a registry is configured a tokenless connection is allowed because each call resolves its own [registry token](#kinds-of-token). Keeping the token out of tool arguments ensures it never enters prompts, model context, or tool-call logs.
 
 #### Base URL — header / env var, or per-call argument
 
@@ -180,41 +180,48 @@ To target **multiple ArgoCD instances, each with its own token**, configure a to
 ARGOCD_TOKEN_REGISTRY_PATH=/app/argocd-mcp/token-registry.json
 ```
 
-The file contains a JSON array mapping a base URL to the token that should be used for it:
+The file contains a JSON array of entries, each keyed by base URL. An entry authenticates its instance one of two ways — set **exactly one** of `token` or `passthrough`:
+
+- `token` — a **static token** configured for that instance. The token stays on the server; the caller only references the URL.
+- `passthrough: true` — **forward the caller's per-request token** (the `x-argocd-api-token` JWT) to that instance, so the end user's own identity reaches ArgoCD for auditability, with no per-instance token to mint. This only authenticates when the same token is accepted by the instance — i.e. a **shared OIDC/SSO** setup where one identity provider fronts every instance (an ArgoCD-local token or PAT is per-instance and will not authenticate elsewhere).
 
 ```json
 [
-  { "baseUrl": "https://argo-a.example.com", "token": "<token-a>" },
-  { "baseUrl": "https://argo-b.example.com", "token": "<token-b>" }
+  { "baseUrl": "https://argo-a.example.com", "passthrough": true },
+  { "baseUrl": "https://argo-b.example.com", "passthrough": true },
+  { "baseUrl": "https://argo-legacy.example.com", "token": "<static-token>" }
 ]
 ```
+
+> **Passthrough needs matching RBAC.** A forwarded identity only succeeds if that user has the required permissions on the target instance; otherwise the call returns a per-instance `403` from ArgoCD (not a routing error). An entry that sets neither `token` nor `passthrough` — or both — is rejected at startup (fail closed), so a secret that fails to mount and leaves `token` blank crashes rather than silently forwarding the JWT.
 
 > **Secure the file.** Restrict it to the server's user (e.g. `chmod 400`) and prefer a secret-management mechanism (Kubernetes secret volume, Vault agent, etc.) over a plaintext file on disk.
 
 > **Local development.** The `make run` / `make dev` targets run without a registry by default; pass `ARGOCD_TOKEN_REGISTRY_PATH=/path/to/tokens.json` to use one. Do **not** place the file under `dist/` — `tsup` runs with `clean: true` and wipes that directory on every build. See [Running locally](#running-locally).
 
-With a registry configured, a caller targets an instance by passing only the (non-secret) `argocdBaseUrl` argument; the server pairs it with the registered token. The token never appears in the tool-call payload.
+With a registry configured, a caller targets an instance by passing only the (non-secret) `argocdBaseUrl` argument; the server pairs it with the registered token (or forwards the request token for a passthrough entry). No token ever appears in the tool-call payload.
 
-##### Two kinds of token
+##### Kinds of token
 
-The server resolves calls using one of two distinct tokens. Keeping them straight is what makes the security model work:
+The server resolves calls using one of these tokens. Keeping them straight is what makes the security model work:
 
-| | **Default token** | **Registry token** |
-|---|---|---|
-| **Source** | `x-argocd-api-token` header / `ARGOCD_API_TOKEN` env var (the session credential) | A `token` entry in the `ARGOCD_TOKEN_REGISTRY_PATH` JSON file, keyed by `baseUrl` |
-| **Scope** | The **default base URL only** (`x-argocd-base-url` / `ARGOCD_BASE_URL`) | The **specific base URL** its entry is keyed to |
-| **Used for** | A call that targets the default base URL | A call that targets any base URL present in the registry (including the default, as a fallback) |
-| **Never used for** | Any base URL other than the default — it is **never** sent to a different host | Any base URL not registered |
+| | **Default token** | **Registry static token** | **Passthrough** |
+|---|---|---|---|
+| **Source** | `x-argocd-api-token` header / `ARGOCD_API_TOKEN` env var (the session credential) | A `token` entry in the registry file, keyed by `baseUrl` | The request token, forwarded to a `passthrough: true` entry |
+| **Scope** | The **default base URL only** (`x-argocd-base-url` / `ARGOCD_BASE_URL`) | The **specific base URL** its entry is keyed to | The **specific base URL** its entry is keyed to |
+| **Used for** | A call that targets the default base URL | A call that targets that registered base URL | A call that targets that registered base URL |
+| **Never used for** | Any base URL other than the default — it is **never** sent to a different host | Any base URL not registered | Any base URL not registered as passthrough |
 
-The cardinal rule: **the default token is bound to the default base URL; every other host's token must come from the registry.** A registry token is bound to exactly the host it is registered under.
+The cardinal rule: **the request token is only ever sent to the default base URL or to a base URL explicitly registered for passthrough; every other host's token must come from a static registry entry.**
 
 ##### Resolution order
 
 For a given call, the resolved base URL is the `argocdBaseUrl` argument if supplied, otherwise the session default. The token is then chosen by:
 
-1. **Call targets the default base URL** → use the **default token**. If no default token was supplied (a tokenless session), fall back to the **registry token** for that base URL, if one exists.
-2. **Call targets any other base URL** → use the **registry token** for that base URL only. The **default token is never used here** — it is not sent to a host other than the default one.
-3. If neither applies (no token can be resolved for the requested base URL), the call returns a "Missing required ArgoCD API token" error and **no request is made** to that host.
+1. **Call targets the default base URL** → use the **default token**. If no default token was supplied (a tokenless session), fall back to the **registry static token** for that base URL, if one exists.
+2. **Call targets a base URL registered with a static token** → use that **static token** (the request token never overrides it).
+3. **Call targets a base URL registered for passthrough** → forward the **request token** to it.
+4. If none applies (no token can be resolved for the requested base URL), the call returns a "Missing required ArgoCD API token" error and **no request is made** to that host.
 
 > **Why the default token is bound to the default base URL.** The `argocdBaseUrl` argument comes from the tool call, so a caller (or a prompt-injected model) could point it at an arbitrary host. If the default token were paired with any supplied base URL, that token would be sent — as an `Authorization: Bearer` header — to the attacker's host. Restricting the default token to the default base URL, and requiring an explicit registry entry for every other host, prevents this token exfiltration. To target additional instances you must register their tokens (and thus their hostnames) up front.
 
@@ -236,7 +243,7 @@ For example, a `tools/call` request overriding only the base URL:
 }
 ```
 
-> **Overriding the base URL to a different instance requires a registry token.** The default token (`x-argocd-api-token` / `ARGOCD_API_TOKEN`) is bound to the default base URL only and is never sent to a different host. Overriding `argocdBaseUrl` to point at the **default** instance (same host, formatting aside) reuses the default token; pointing it at any **other** instance requires a [registry token](#two-kinds-of-token) for that instance, otherwise the call fails with "Missing required ArgoCD API token" and no request is sent. This is intentional — see [why the default token is bound to the default base URL](#token-registry--per-base-url-tokens-multi-instance) above.
+> **Overriding the base URL to a different instance requires a registry token.** The default token (`x-argocd-api-token` / `ARGOCD_API_TOKEN`) is bound to the default base URL only and is never sent to a different host. Overriding `argocdBaseUrl` to point at the **default** instance (same host, formatting aside) reuses the default token; pointing it at any **other** instance requires a [registry entry](#kinds-of-token) for that instance — either a static token or `passthrough: true` — otherwise the call fails with "Missing required ArgoCD API token" and no request is sent. This is intentional — see [why the default token is bound to the default base URL](#token-registry--per-base-url-tokens-multi-instance) above.
 
 ### Read Only Mode
 

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -80,6 +80,42 @@ test('overridden base URL with a registry entry uses the registry token, not the
   assert.notEqual(client.client.apiToken, DEFAULT_TOKEN);
 });
 
+test('overridden base URL registered for passthrough forwards the request token', async () => {
+  // A passthrough entry lets the caller's identity flow through to a second
+  // instance: resolveClient pairs the override URL with the request token
+  // (DEFAULT_TOKEN here) rather than failing or minting a per-instance token.
+  const registry = new TokenRegistry([{ baseUrl: OTHER_BASE_URL, passthrough: true }]);
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: registry
+  });
+
+  const client = (
+    server as unknown as {
+      resolveClient: (a: { argocdBaseUrl?: string }) => unknown;
+    }
+  ).resolveClient({ argocdBaseUrl: OTHER_BASE_URL }) as { client: { apiToken: string } };
+
+  assert.equal(client.client.apiToken, DEFAULT_TOKEN);
+});
+
+test('passthrough entry with no request token fails closed (no token to forward)', async () => {
+  // Passthrough only works when the caller actually presented a token. With an
+  // empty session token there is nothing to forward, so the call must fail
+  // rather than send a blank token to the instance.
+  const registry = new TokenRegistry([{ baseUrl: OTHER_BASE_URL, passthrough: true }]);
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: '',
+    tokenRegistry: registry
+  });
+
+  const result = await callTool(server, 'list_applications', { argocdBaseUrl: OTHER_BASE_URL });
+  assert.equal(result.isError, true);
+  assert.match(textOf(result), /Missing required ArgoCD API token/);
+});
+
 test('default base URL uses the default token', async () => {
   const server = createServer({
     argocdBaseUrl: DEFAULT_BASE_URL,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -379,15 +379,18 @@ export class Server extends McpServer {
   // overridden per call via the argocdBaseUrl argument; the API token is never a
   // tool argument and is resolved by the following precedence:
   //
-  //   1. Request token  — the session token from the x-argocd-api-token header /
-  //      ARGOCD_API_TOKEN env var. If the caller supplied one, it ALWAYS wins.
-  //   2. Registry token — when no request token was supplied, look the resolved
-  //      base URL up in the configured token registry (ARGOCD_TOKEN_REGISTRY)
-  //      and use its token if the base URL is registered.
+  //   1. Default base URL  — the request token (x-argocd-api-token header /
+  //      ARGOCD_API_TOKEN env var) is used, falling back to a static registry
+  //      token if the default URL is also registered. Original behaviour.
+  //   2. Registry static token — a base URL registered with a static token
+  //      always uses that token (the request token never overrides it).
+  //   3. Registry passthrough — a base URL registered with passthrough: true
+  //      forwards the request token, letting the end user's identity reach that
+  //      instance (for auditability) with no per-instance token to mint.
   //
-  // This lets a single server target multiple ArgoCD instances, each with its
-  // own token, without the token ever appearing in a tool-call payload: callers
-  // pass only the (non-secret) base URL and the server pairs it with the token.
+  // Any base URL that is neither the default nor registered is rejected: the
+  // request token is only forwarded to pre-approved URLs, so a prompt-injected
+  // argocdBaseUrl value cannot redirect the token to an arbitrary host.
   private resolveClient(args: ArgoCDArgs): ArgoCDClient {
     const baseUrl = args.argocdBaseUrl || this.defaultBaseUrl;
 
@@ -401,17 +404,22 @@ export class Server extends McpServer {
       );
     }
 
-    // Resolve the token for this base URL. The default (session) token is bound
-    // to the default base URL ONLY: it must never be paired with a caller-
-    // supplied base URL, or an attacker (or prompt-injected model) could set
-    // argocdBaseUrl to an arbitrary host and have the server send the default
-    // token there (token exfiltration). For any overridden base URL, the token
-    // must come from the registry — i.e. the operator explicitly registered it.
+    // Resolve the token for this base URL. The request token is only ever
+    // forwarded to the default URL or to a registered passthrough URL; a URL
+    // with a static registry token always uses that token, and any other URL is
+    // rejected below — preventing a prompt-injected argocdBaseUrl from
+    // exfiltrating the request token to an arbitrary host.
     const isDefaultBaseUrl =
       TokenRegistry.normalize(baseUrl) === TokenRegistry.normalize(this.defaultBaseUrl);
-    const apiToken = isDefaultBaseUrl
-      ? this.defaultApiToken || this.tokenRegistry.getToken(baseUrl)
-      : this.tokenRegistry.getToken(baseUrl);
+    const registryToken = this.tokenRegistry.getToken(baseUrl);
+    let apiToken: string | undefined;
+    if (isDefaultBaseUrl) {
+      apiToken = this.defaultApiToken || registryToken;
+    } else if (registryToken) {
+      apiToken = registryToken;
+    } else if (this.tokenRegistry.isPassthrough(baseUrl)) {
+      apiToken = this.defaultApiToken;
+    }
 
     if (!apiToken) {
       throw new Error(

--- a/src/server/tokenRegistry.test.ts
+++ b/src/server/tokenRegistry.test.ts
@@ -47,29 +47,65 @@ test('an empty registry has size 0 and finds nothing', () => {
 
 // --- Fail-closed: constructor rejects malformed entries ------------------
 
-test('constructor throws when an entry is missing its token', () => {
+test('constructor throws when an entry is missing its base URL', () => {
+  assert.throws(() => new TokenRegistry([{ baseUrl: '', token: 'token-a' }]), /missing baseUrl/);
+});
+
+test('constructor throws when an entry has neither a token nor passthrough', () => {
+  assert.throws(
+    () => new TokenRegistry([{ baseUrl: 'https://argo-a.example.com' }]),
+    /must specify either a token or passthrough/
+  );
+  // An empty token is NOT treated as passthrough: it fails closed so a secret
+  // that fails to mount crashes at startup instead of forwarding the JWT.
   assert.throws(
     () => new TokenRegistry([{ baseUrl: 'https://argo-a.example.com', token: '' }]),
-    /missing baseUrl or token/
+    /must specify either a token or passthrough/
   );
 });
 
-test('constructor throws when an entry is missing its base URL', () => {
+test('constructor throws when an entry sets both a token and passthrough', () => {
   assert.throws(
-    () => new TokenRegistry([{ baseUrl: '', token: 'token-a' }]),
-    /missing baseUrl or token/
+    () =>
+      new TokenRegistry([
+        { baseUrl: 'https://argo-a.example.com', token: 'token-a', passthrough: true }
+      ]),
+    /cannot set both a token and passthrough/
   );
 });
 
 test('constructor error does not leak the token value', () => {
   assert.throws(
-    () => new TokenRegistry([{ baseUrl: '', token: 'super-secret-token' }]),
+    () =>
+      new TokenRegistry([
+        { baseUrl: 'https://argo-a.example.com', token: 'super-secret-token', passthrough: true }
+      ]),
     (error: unknown) => {
       assert.ok(error instanceof Error);
       assert.ok(!error.message.includes('super-secret-token'));
       return true;
     }
   );
+});
+
+test('constructor accepts a passthrough entry with no static token', () => {
+  const registry = new TokenRegistry([
+    { baseUrl: 'https://argo-a.example.com', passthrough: true }
+  ]);
+  assert.equal(registry.getSize(), 1);
+  assert.equal(registry.getToken('https://argo-a.example.com'), undefined);
+  assert.equal(registry.isPassthrough('https://argo-a.example.com'), true);
+});
+
+test('isPassthrough is false for a static-token entry and unregistered URLs', () => {
+  const registry = new TokenRegistry([
+    { baseUrl: 'https://argo-a.example.com', token: 'token-a' },
+    { baseUrl: 'https://argo-b.example.com', passthrough: true }
+  ]);
+  assert.equal(registry.isPassthrough('https://argo-a.example.com'), false);
+  assert.equal(registry.isPassthrough('https://argo-b.example.com'), true);
+  assert.equal(registry.isPassthrough('https://argo-c.example.com'), false);
+  assert.equal(registry.isPassthrough(''), false);
 });
 
 // --- parseTokenRegistry --------------------------------------------------

--- a/src/server/tokenRegistry.ts
+++ b/src/server/tokenRegistry.ts
@@ -1,22 +1,32 @@
 import { readFileSync } from 'node:fs';
 import { logger } from '../logging/logging.js';
 
-// A read-only registry that maps an ArgoCD base URL to the API token that
-// should be used for it. It lets a single server target multiple ArgoCD
-// instances — each with its own token — without the token ever being passed in
-// a tool-call payload: the caller supplies only the (non-secret) base URL and
-// the server pairs it with the configured token.
+// A read-only registry that maps an ArgoCD base URL to how it should be
+// authenticated. It lets a single server target multiple ArgoCD instances
+// without any token ever being passed in a tool-call payload: the caller
+// supplies only the (non-secret) base URL and the server resolves the token.
+//
+// Each entry authenticates a base URL one of two ways (exactly one is required):
+//
+//   • token       — a static token configured for that instance. The token
+//                   never leaves the server; the caller only references the URL.
+//   • passthrough — forward the caller's per-request token (the JWT from the
+//                   x-argocd-api-token header) to that instance. This lets the
+//                   end user's own identity flow through for auditability, with
+//                   no per-instance token to mint. It only authenticates when
+//                   the same token is accepted by the instance — i.e. a shared
+//                   OIDC/SSO setup where one IdP fronts every instance.
 //
 // Configuration source: a JSON file whose path is given by the
 // ARGOCD_TOKEN_REGISTRY_PATH environment variable. The tokens are secrets, so
 // they are read from a file (e.g. a mounted Kubernetes secret) rather than an
 // env var, keeping them out of the process environment, crash dumps, and child
-// process inheritance. The file contains a JSON array of { baseUrl, token }
-// entries, e.g.
+// process inheritance. The file contains a JSON array of entries, e.g.
 //
 //   [
-//     {"baseUrl":"https://argo-a.example.com","token":"<token-a>"},
-//     {"baseUrl":"https://argo-b.example.com","token":"<token-b>"}
+//     {"baseUrl":"https://argo-a.example.com","passthrough":true},
+//     {"baseUrl":"https://argo-b.example.com","passthrough":true},
+//     {"baseUrl":"https://argo-legacy.example.com","token":"<static-token>"}
 //   ]
 //
 // Base URLs are normalized (lowercased host, trailing slashes stripped) so
@@ -24,32 +34,65 @@ import { logger } from '../logging/logging.js';
 // value don't cause a lookup miss.
 export type TokenRegistryEntry = {
   baseUrl: string;
-  token: string;
+  token?: string;
+  passthrough?: boolean;
+};
+
+type RegistryEntry = {
+  token?: string;
+  passthrough: boolean;
 };
 
 export class TokenRegistry {
-  private tokensByBaseUrl = new Map<string, string>();
+  private entriesByBaseUrl = new Map<string, RegistryEntry>();
 
   constructor(entries: TokenRegistryEntry[] = []) {
     for (const entry of entries) {
-      if (!entry.baseUrl || !entry.token) {
-        // Fail closed: a missing baseUrl/token is a misconfigured credential,
-        // not something to silently skip. Don't include the token in the error.
-        throw new Error('ArgoCD token registry entry is missing baseUrl or token');
+      if (!entry.baseUrl) {
+        throw new Error('ArgoCD token registry entry is missing baseUrl');
       }
-      this.tokensByBaseUrl.set(TokenRegistry.normalize(entry.baseUrl), entry.token);
+      const hasToken = !!entry.token;
+      const passthrough = entry.passthrough === true;
+      // Fail closed: an entry must authenticate exactly one way. Requiring an
+      // explicit `passthrough: true` (rather than treating an empty token as
+      // passthrough) means a secret that fails to mount — leaving token blank —
+      // crashes at startup instead of silently forwarding the caller's JWT.
+      // Never include the token value in these errors.
+      if (!hasToken && !passthrough) {
+        throw new Error(
+          `ArgoCD token registry entry for "${entry.baseUrl}" must specify either a token or passthrough: true`
+        );
+      }
+      if (hasToken && passthrough) {
+        throw new Error(
+          `ArgoCD token registry entry for "${entry.baseUrl}" cannot set both a token and passthrough: true`
+        );
+      }
+      this.entriesByBaseUrl.set(TokenRegistry.normalize(entry.baseUrl), {
+        token: hasToken ? entry.token : undefined,
+        passthrough
+      });
     }
   }
 
-  // Returns the configured token for the given base URL, or undefined when the
-  // base URL is not registered.
+  // Returns the configured static token for the given base URL, or undefined
+  // when the base URL is not registered or is a passthrough entry (no static
+  // token).
   public getToken(baseUrl: string): string | undefined {
     if (!baseUrl) return undefined;
-    return this.tokensByBaseUrl.get(TokenRegistry.normalize(baseUrl));
+    return this.entriesByBaseUrl.get(TokenRegistry.normalize(baseUrl))?.token;
+  }
+
+  // Returns true when the base URL is registered as a passthrough entry, meaning
+  // the caller's per-request token should be forwarded to it. Used to decide
+  // whether to forward the JWT to a non-default URL.
+  public isPassthrough(baseUrl: string): boolean {
+    if (!baseUrl) return false;
+    return this.entriesByBaseUrl.get(TokenRegistry.normalize(baseUrl))?.passthrough ?? false;
   }
 
   public getSize(): number {
-    return this.tokensByBaseUrl.size;
+    return this.entriesByBaseUrl.size;
   }
 
   // Normalize a base URL for stable lookups: lowercase the scheme+host and drop

--- a/src/server/tokenRegistry.ts
+++ b/src/server/tokenRegistry.ts
@@ -13,9 +13,12 @@ import { logger } from '../logging/logging.js';
 //   • passthrough — forward the caller's per-request token (the JWT from the
 //                   x-argocd-api-token header) to that instance. This lets the
 //                   end user's own identity flow through for auditability, with
-//                   no per-instance token to mint. It only authenticates when
-//                   the same token is accepted by the instance — i.e. a shared
-//                   OIDC/SSO setup where one IdP fronts every instance.
+//                   no per-instance token to mint. The forwarded token must be
+//                   one the instance accepts: an OIDC/SSO token whose audience
+//                   matches that instance's OIDC client. Each instance validates
+//                   its own audience, so a token is scoped to a single instance
+//                   and the caller presents the right token per request. See the
+//                   passthrough security notes in the README before enabling it.
 //
 // Configuration source: a JSON file whose path is given by the
 // ARGOCD_TOKEN_REGISTRY_PATH environment variable. The tokens are secrets, so


### PR DESCRIPTION
## Summary

Lets a single MCP server target **many ArgoCD instances** while flowing the **end user's identity** through to each, so ArgoCD's audit log and RBAC attribute actions to the real user rather than a shared service token — with no per-instance token to mint.

Each token registry entry now authenticates one of two ways (**exactly one** required):

- `token` — a static token configured for that instance (existing behaviour, unchanged).
- `passthrough: true` — forward the caller's per-request token (`x-argocd-api-token`) to that instance.

```json
[
  { "baseUrl": "https://argo-a.example.com", "passthrough": true },
  { "baseUrl": "https://argo-b.example.com", "passthrough": true },
  { "baseUrl": "https://argo-legacy.example.com", "token": "<static-token>" }
]
```

## Token resolution precedence

1. **Default base URL** → request token (fallback: static registry token)
2. **Static-token entry** → that static token (request token never overrides it)
3. **Passthrough entry** → forward the request token
4. **Otherwise** → rejected, no request made

## Security

- **Anti-exfiltration preserved.** The request token only ever reaches the default URL or a pre-approved passthrough URL, so a prompt-injected `argocdBaseUrl` cannot redirect it to an arbitrary host. URL matching keys off `origin` (drops userinfo), so `https://host@evil.com` normalizes to `evil.com` and is denied.
- **Fail-closed.** An entry with neither `token` nor `passthrough` (or both) is rejected at startup, so a secret that fails to mount and leaves the token blank crashes rather than silently enabling passthrough.
- **Audience validation is the load-bearing control.** Passthrough is intended for an OIDC/SSO setup with one OIDC client (app) per instance: each instance validates its own audience, so a forwarded token is scoped to a single instance and cannot be replayed against the others. The README documents this as a hard requirement (including the ways it can be accidentally relaxed) and notes that multi-instance use needs stateless mode, since one token authenticates to exactly one instance.

## Backward compatibility

Static-token entries behave exactly as before. The `passthrough` field is optional and additive; existing registry files and single-instance deployments are unaffected.

## Also included

- `.dockerignore` — without it, `COPY . /app` in the Dockerfile pulls the host's `node_modules` into the image and a local install collides with the pnpm layout from the prod-deps stage. Excluding `node_modules`/`dist`/`.git` fixes local builds and shrinks the build context.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (27 passing — added coverage for passthrough resolution, fail-closed validation, and a restored token-leak guard)
- [x] `npm run build`
- [x] `docker build` + container boot: mixed passthrough/static registry loads, `/healthz` returns 200, malformed registry fails closed at startup