### PR TITLE
feat: add a new tool to fetch AppProject resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ The server provides the following ArgoCD management tools:
 ### Cluster Management
 - `list_clusters`: List all clusters registered with ArgoCD
 
+### Project Management
+- `get_appproject`: Get detailed information about a specific AppProject (project)
+
 ### Application Management
 - `list_applications`: List and filter all applications
 - `get_application`: Get detailed information about a specific application

--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -8,7 +8,8 @@ import {
   V1alpha1ResourceDiff,
   V1alpha1ResourceResult,
   V1alpha1ApplicationResourceResult,
-  V1alpha1ClusterList
+  V1alpha1ClusterList,
+  V1alpha1AppProject
 } from '../types/argocd-types.js';
 import { HttpClient } from './http.js';
 
@@ -85,6 +86,11 @@ export class ArgoCDClient {
       `/api/v1/applications/${applicationName}`,
       queryParams
     );
+    return body;
+  }
+
+  public async getAppProject(projectName: string) {
+    const { body } = await this.client.get<V1alpha1AppProject>(`/api/v1/projects/${projectName}`);
     return body;
   }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -124,6 +124,14 @@ export class Server extends McpServer {
         await client.getApplication(applicationName, applicationNamespace)
     );
     this.addJsonOutputTool(
+      'get_appproject',
+      'get_appproject returns an ArgoCD AppProject (project) by its name. AppProjects provide a logical grouping of applications and define allowed sources, destinations, cluster/repository whitelists, and RBAC roles.',
+      {
+        projectName: z.string().describe('The name of the ArgoCD AppProject to fetch.')
+      },
+      async ({ projectName }, client) => await client.getAppProject(projectName)
+    );
+    this.addJsonOutputTool(
       'get_application_resource_tree',
       'get_application_resource_tree returns resource tree for application by application name. Optionally specify the application namespace to get resource tree from applications in non-default namespaces.',
       {

--- a/src/types/argocd-types.ts
+++ b/src/types/argocd-types.ts
@@ -13,3 +13,4 @@ export type V1alpha1ResourceResult = ArgoCD.V1alpha1ResourceResult;
 export type V1alpha1ApplicationResourceResult = ArgoCD.ApplicationApplicationResourceResponse;
 export type V1alpha1Cluster = ArgoCD.V1alpha1Cluster;
 export type V1alpha1ClusterList = ArgoCD.V1alpha1ClusterList;
+export type V1alpha1AppProject = ArgoCD.V1alpha1AppProject;


### PR DESCRIPTION
## Summary

Adds a new `get_appproject` tool that fetches an ArgoCD **AppProject** (project) by name from the ArgoCD API.

AppProjects provide a logical grouping of applications and define allowed sources, destinations, cluster/repository whitelists, and RBAC roles. Until now the MCP server exposed application- and cluster-level tools but had no way to inspect a project, which is often needed to understand why an application's source/destination is (dis)allowed.

## Changes

- **`src/argocd/client.ts`** — new `getAppProject(projectName)` method calling `GET /api/v1/projects/{name}` and returning a `V1alpha1AppProject`. Mirrors the existing `getApplication` pattern.
- **`src/server/server.ts`** — register the `get_appproject` tool with a single required `projectName` string argument. It inherits the standard per-call `argocdBaseUrl` override and token-resolution handling via `addJsonOutputTool`.
- **`src/types/argocd-types.ts`** — re-export `V1alpha1AppProject` from the generated ArgoCD types.
- **`README.md`** — document the new tool under a "Project Management" section.

## Behavior notes

- `get_appproject` is a **read-only** tool: it is registered in the always-on read/query block, ahead of the `if (!isReadOnly)` gate, so it remains available when `MCP_READ_ONLY=true` (mutating tools stay gated off). Verified at runtime.

## Testing

- `tsc --noEmit` — clean
- `pnpm build` — success
- `pnpm test` — 22/22 passing
- `pnpm lint` — clean
- Runtime check with `MCP_READ_ONLY=true`: `get_appproject` is registered, mutating tools (e.g. `create_application`) are not.

## Example

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "tools/call",
  "params": {
    "name": "get_appproject",
    "arguments": { "projectName": "default" }
  }
}
```
