### PR TITLE
feat: add project/destCluster filters to list_applications and a list_projects tool

### DIFF
--- a/src/argocd/client.test.ts
+++ b/src/argocd/client.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { matchesDestCluster } from './client.js';
+
+const identifiers = new Set(['prod', 'https://10.0.0.1:6443']);
+
+test('matchesDestCluster matches by destination name', () => {
+  assert.equal(matchesDestCluster({ name: 'prod' }, identifiers), true);
+});
+
+test('matchesDestCluster matches by destination server URL', () => {
+  assert.equal(matchesDestCluster({ server: 'https://10.0.0.1:6443' }, identifiers), true);
+});
+
+test('matchesDestCluster matches a name-only destination against a set resolved from a URL', () => {
+  // The caller resolved "https://10.0.0.1:6443" to the registered cluster and
+  // expanded the set with its name; a name-only destination must match.
+  assert.equal(matchesDestCluster({ name: 'prod' }, identifiers), true);
+  assert.equal(matchesDestCluster({ server: 'https://10.0.0.1:6443' }, identifiers), true);
+});
+
+test('matchesDestCluster does not match a different cluster', () => {
+  assert.equal(matchesDestCluster({ name: 'staging' }, identifiers), false);
+  assert.equal(matchesDestCluster({ server: 'https://10.0.0.2:6443' }, identifiers), false);
+});
+
+test('matchesDestCluster does not match an undefined destination', () => {
+  assert.equal(matchesDestCluster(undefined, identifiers), false);
+});
+
+test('matchesDestCluster is an exact match, not a substring match', () => {
+  assert.equal(matchesDestCluster({ name: 'prod-eu' }, identifiers), false);
+  assert.equal(matchesDestCluster({ server: '10.0.0.1' }, identifiers), false);
+});

--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -56,7 +56,10 @@ export class ArgoCDClient {
       Object.keys(queryParams).length > 0 ? queryParams : undefined
     );
 
-    // Strip heavy fields to reduce token usage
+    // Strip heavy fields to reduce token usage: the full source (helm/kustomize
+    // parameters), sync.comparedTo (a copy of source + destination) and
+    // status.summary (image/URL lists) are dropped; get_application returns
+    // the complete resource for a single application.
     let strippedItems =
       body.items?.map((app) => ({
         metadata: {
@@ -67,13 +70,20 @@ export class ArgoCDClient {
         },
         spec: {
           project: app.spec?.project,
-          source: app.spec?.source,
+          source: app.spec?.source && {
+            repoURL: app.spec.source.repoURL,
+            path: app.spec.source.path,
+            chart: app.spec.source.chart,
+            targetRevision: app.spec.source.targetRevision
+          },
           destination: app.spec?.destination
         },
         status: {
-          sync: app.status?.sync,
-          health: app.status?.health,
-          summary: app.status?.summary
+          sync: app.status?.sync && {
+            status: app.status.sync.status,
+            revision: app.status.sync.revision
+          },
+          health: app.status?.health
         }
       })) ?? [];
 

--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -9,9 +9,23 @@ import {
   V1alpha1ResourceResult,
   V1alpha1ApplicationResourceResult,
   V1alpha1ClusterList,
-  V1alpha1AppProject
+  V1alpha1AppProject,
+  V1alpha1AppProjectList
 } from '../types/argocd-types.js';
 import { HttpClient } from './http.js';
+
+/**
+ * Matches an application destination against a set of cluster identifiers
+ * (names and/or API server URLs). Applications may reference their destination
+ * cluster either by name (`spec.destination.name`) or by API server URL
+ * (`spec.destination.server`), so both fields are checked.
+ */
+export const matchesDestCluster = (
+  destination: { name?: string; server?: string } | undefined,
+  identifiers: ReadonlySet<string>
+): boolean =>
+  (destination?.name != null && identifiers.has(destination.name)) ||
+  (destination?.server != null && identifiers.has(destination.server));
 
 export class ArgoCDClient {
   private baseUrl: string;
@@ -24,14 +38,26 @@ export class ArgoCDClient {
     this.client = new HttpClient(this.baseUrl, this.apiToken);
   }
 
-  public async listApplications(params?: { search?: string; limit?: number; offset?: number }) {
+  public async listApplications(params?: {
+    search?: string;
+    project?: string;
+    destCluster?: string;
+    limit?: number;
+    offset?: number;
+  }) {
+    const queryParams: Record<string, string> = {};
+    if (params?.search) queryParams.search = params.search;
+    // The ArgoCD API filters by project server-side via the (repeatable)
+    // `projects` query parameter; a single value is enough here.
+    if (params?.project) queryParams.projects = params.project;
+
     const { body } = await this.client.get<V1alpha1ApplicationList>(
       `/api/v1/applications`,
-      params?.search ? { search: params.search } : undefined
+      Object.keys(queryParams).length > 0 ? queryParams : undefined
     );
 
     // Strip heavy fields to reduce token usage
-    const strippedItems =
+    let strippedItems =
       body.items?.map((app) => ({
         metadata: {
           name: app.metadata?.name,
@@ -51,6 +77,18 @@ export class ArgoCDClient {
         }
       })) ?? [];
 
+    // The applications list API cannot filter by destination cluster, so the
+    // filter is applied here, after stripping and before pagination. The
+    // identifier is first resolved against the registered clusters so that
+    // applications referencing the destination by the other identifier (name
+    // vs. API server URL) are matched too.
+    if (params?.destCluster) {
+      const identifiers = await this.resolveDestClusterIdentifiers(params.destCluster);
+      strippedItems = strippedItems.filter((app) =>
+        matchesDestCluster(app.spec.destination, identifiers)
+      );
+    }
+
     // Apply pagination
     const start = params?.offset ?? 0;
     const end = params?.limit ? start + params.limit : strippedItems.length;
@@ -65,6 +103,28 @@ export class ArgoCDClient {
         hasMore: end < strippedItems.length
       }
     };
+  }
+
+  /**
+   * Expands a destination-cluster identifier (name or API server URL) with the
+   * matching registered cluster's other identifier, so applications that
+   * reference the destination either way are matched. Falls back to the raw
+   * identifier when the clusters cannot be listed (e.g. missing RBAC).
+   */
+  private async resolveDestClusterIdentifiers(destCluster: string): Promise<Set<string>> {
+    const identifiers = new Set([destCluster]);
+    try {
+      const clusters = await this.listClusters();
+      for (const cluster of clusters.items ?? []) {
+        if (cluster.name === destCluster || cluster.server === destCluster) {
+          if (cluster.name) identifiers.add(cluster.name);
+          if (cluster.server) identifiers.add(cluster.server);
+        }
+      }
+    } catch {
+      // Ignore: matching proceeds with the raw identifier only.
+    }
+    return identifiers;
   }
 
   public async listClusters(params?: { server?: string; name?: string }) {
@@ -92,6 +152,34 @@ export class ArgoCDClient {
   public async getAppProject(projectName: string) {
     const { body } = await this.client.get<V1alpha1AppProject>(`/api/v1/projects/${projectName}`);
     return body;
+  }
+
+  public async listProjects() {
+    const { body } = await this.client.get<V1alpha1AppProjectList>(`/api/v1/projects`);
+
+    // Strip heavy fields to reduce token usage; get_appproject returns the
+    // full resource for a single project.
+    const items =
+      body.items?.map((project) => ({
+        metadata: {
+          name: project.metadata?.name,
+          labels: project.metadata?.labels,
+          creationTimestamp: project.metadata?.creationTimestamp
+        },
+        spec: {
+          description: project.spec?.description,
+          sourceRepos: project.spec?.sourceRepos,
+          destinations: project.spec?.destinations
+        }
+      })) ?? [];
+
+    return {
+      items,
+      metadata: {
+        resourceVersion: body.metadata?.resourceVersion,
+        totalItems: items.length
+      }
+    };
   }
 
   public async createApplication(application: V1alpha1Application) {

--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -27,6 +27,31 @@ export const matchesDestCluster = (
   (destination?.name != null && identifiers.has(destination.name)) ||
   (destination?.server != null && identifiers.has(destination.server));
 
+// MCP clients cap the size of a tool result and cut the middle out of anything
+// larger, which turns an oversized list into a silently partial one. The list
+// tools therefore paginate by default instead of returning everything: a short
+// page plus explicit `hasMore` is always a correct answer, a truncated JSON
+// never is.
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_LIST_LIMIT = 200;
+
+const paginate = <T>(items: T[], params?: { limit?: number; offset?: number }) => {
+  const start = Math.max(params?.offset ?? 0, 0);
+  const limit = Math.min(Math.max(params?.limit ?? DEFAULT_LIST_LIMIT, 1), MAX_LIST_LIMIT);
+  const end = start + limit;
+  const page = items.slice(start, end);
+  return {
+    items: page,
+    metadata: {
+      totalItems: items.length,
+      returnedItems: page.length,
+      offset: start,
+      limit,
+      hasMore: end < items.length
+    }
+  };
+};
+
 export class ArgoCDClient {
   private baseUrl: string;
   private apiToken: string;
@@ -99,18 +124,16 @@ export class ArgoCDClient {
       );
     }
 
-    // Apply pagination
-    const start = params?.offset ?? 0;
-    const end = params?.limit ? start + params.limit : strippedItems.length;
-    const items = strippedItems.slice(start, end);
+    // Apply pagination. The limit is enforced even when the caller omits it:
+    // an unfiltered inventory is thousands of applications and would come back
+    // to the model with its middle cut away.
+    const { items, metadata } = paginate(strippedItems, params);
 
     return {
       items,
       metadata: {
         resourceVersion: body.metadata?.resourceVersion,
-        totalItems: strippedItems.length,
-        returnedItems: items.length,
-        hasMore: end < strippedItems.length
+        ...metadata
       }
     };
   }
@@ -147,7 +170,34 @@ export class ArgoCDClient {
       Object.keys(queryParams).length > 0 ? queryParams : undefined
     );
 
-    return body;
+    // Cluster items are stripped for the same reason as the application ones:
+    // info.apiVersions alone lists every group/version served by a cluster
+    // (hundreds of strings each), and config/info.cacheInfo add more weight on
+    // top. A deployment with a few dozen clusters overflows the client-side
+    // output limit, the middle of the list is cut away and the caller silently
+    // receives a partial inventory. Identity plus health is what a list is for;
+    // the connection message is kept because there is no per-cluster get tool
+    // to fall back to when a cluster is unreachable.
+    const items =
+      body.items?.map((cluster) => ({
+        name: cluster.name,
+        server: cluster.server,
+        serverVersion: cluster.serverVersion || cluster.info?.serverVersion,
+        applicationsCount: cluster.info?.applicationsCount,
+        connectionState: cluster.connectionState && {
+          status: cluster.connectionState.status,
+          message: cluster.connectionState.message,
+          attemptedAt: cluster.connectionState.attemptedAt
+        }
+      })) ?? [];
+
+    return {
+      items,
+      metadata: {
+        resourceVersion: body.metadata?.resourceVersion,
+        totalItems: items.length
+      }
+    };
   }
 
   public async getApplication(applicationName: string, appNamespace?: string) {
@@ -164,30 +214,38 @@ export class ArgoCDClient {
     return body;
   }
 
-  public async listProjects() {
+  public async listProjects(params?: { search?: string; limit?: number; offset?: number }) {
     const { body } = await this.client.get<V1alpha1AppProjectList>(`/api/v1/projects`);
 
-    // Strip heavy fields to reduce token usage; get_appproject returns the
-    // full resource for a single project.
-    const items =
+    // A project list answers "which projects exist"; the repository allow-list
+    // and the destination allow-list behind each project are what make the
+    // response heavy, so they are reduced to counts here and returned in full
+    // by get_appproject for the single project the caller cares about.
+    let strippedItems =
       body.items?.map((project) => ({
-        metadata: {
-          name: project.metadata?.name,
-          labels: project.metadata?.labels,
-          creationTimestamp: project.metadata?.creationTimestamp
-        },
-        spec: {
-          description: project.spec?.description,
-          sourceRepos: project.spec?.sourceRepos,
-          destinations: project.spec?.destinations
-        }
+        name: project.metadata?.name,
+        description: project.spec?.description,
+        sourceReposCount: project.spec?.sourceRepos?.length ?? 0,
+        destinationsCount: project.spec?.destinations?.length ?? 0,
+        creationTimestamp: project.metadata?.creationTimestamp
       })) ?? [];
+
+    // The projects API has no server-side search, so the substring filter is
+    // applied here — same contract as list_applications.
+    if (params?.search) {
+      const needle = params.search.toLowerCase();
+      strippedItems = strippedItems.filter((project) =>
+        project.name?.toLowerCase().includes(needle)
+      );
+    }
+
+    const { items, metadata } = paginate(strippedItems, params);
 
     return {
       items,
       metadata: {
         resourceVersion: body.metadata?.resourceVersion,
-        totalItems: items.length
+        ...metadata
       }
     };
   }

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -175,3 +175,36 @@ test('with no default token, an overridden URL still resolves only from the regi
   assert.equal(result.isError, true);
   assert.match(textOf(result), /Missing required ArgoCD API token/);
 });
+
+test('list_projects is registered and enforces the same token-resolution boundary', async () => {
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry()
+  });
+
+  // callTool asserts the tool is registered; the unregistered override must
+  // fail before any HTTP request, keeping this test hermetic.
+  const result = await callTool(server, 'list_projects', { argocdBaseUrl: EVIL_BASE_URL });
+  assert.equal(result.isError, true);
+  assert.match(textOf(result), /Missing required ArgoCD API token/);
+});
+
+test('list_applications accepts the project and destCluster filter arguments', async () => {
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry()
+  });
+
+  // Schema validation runs before token resolution: unknown/invalid arguments
+  // would be rejected by the SDK, while valid ones reach resolveClient and fail
+  // there (hermetically) on the unregistered base URL.
+  const result = await callTool(server, 'list_applications', {
+    argocdBaseUrl: EVIL_BASE_URL,
+    project: 'default',
+    destCluster: 'in-cluster'
+  });
+  assert.equal(result.isError, true);
+  assert.match(textOf(result), /Missing required ArgoCD API token/);
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -68,7 +68,7 @@ export class Server extends McpServer {
     // Always register read/query tools
     this.addJsonOutputTool(
       'list_applications',
-      'list_applications returns list of applications',
+      'list_applications returns a page of applications with their project, source and sync/health status. Filters (search by name, project, destCluster) are applied server-side, so filtering is always cheaper and more reliable than listing everything and picking by eye. The response carries metadata.totalItems and metadata.hasMore: page with offset until hasMore is false to cover the whole set.',
       {
         search: z
           .string()
@@ -94,7 +94,7 @@ export class Server extends McpServer {
           .positive()
           .optional()
           .describe(
-            'Maximum number of applications to return. Use this to reduce token usage when there are many applications. Optional.'
+            'Maximum number of applications to return, 1-200. Defaults to 50 when omitted: the response is always a bounded page, never the whole inventory. Optional.'
           ),
         offset: z
           .number()
@@ -116,7 +116,7 @@ export class Server extends McpServer {
     );
     this.addJsonOutputTool(
       'list_clusters',
-      'list_clusters returns list of clusters registered with ArgoCD',
+      'list_clusters returns every cluster registered with ArgoCD: name, API server URL, connection status, Kubernetes version and application count. The list is complete — it is not paginated and heavy per-cluster details (API versions, connection config, cache stats) are omitted, so the whole inventory fits in a single response.',
       {
         server: z.string().optional().describe('Filter clusters by server URL. Optional.'),
         name: z.string().optional().describe('Filter clusters by name. Optional.')
@@ -147,9 +147,31 @@ export class Server extends McpServer {
     );
     this.addJsonOutputTool(
       'list_projects',
-      'list_projects returns the list of ArgoCD AppProjects with their name, description, source repositories and allowed destinations (clusters/namespaces). Use it to discover which projects exist and which clusters they may deploy to; use get_appproject for the full details of a single project.',
-      {},
-      async (_args, client) => await client.listProjects()
+      'list_projects returns the ArgoCD AppProjects: name, description and how many source repositories and destinations each one allows. Use it to discover which projects exist; use get_appproject when the actual repository and destination lists of a single project are needed. Projects are not clusters — a project is a logical grouping of applications and may be named after something else entirely; use list_clusters for the cluster inventory.',
+      {
+        search: z
+          .string()
+          .optional()
+          .describe('Filter projects by name, partial match, case-insensitive. Optional.'),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            'Maximum number of projects to return, 1-200. Defaults to 50 when omitted. Optional.'
+          ),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            'Number of projects to skip before returning results. Use with limit for pagination. Optional.'
+          )
+      },
+      async ({ search, limit, offset }, client) =>
+        await client.listProjects({ search: search ?? undefined, limit, offset })
     );
     this.addJsonOutputTool(
       'get_application_resource_tree',

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -76,6 +76,18 @@ export class Server extends McpServer {
           .describe(
             'Search applications by name. This is a partial match on the application name and does not support glob patterns (e.g. "*"). Optional.'
           ),
+        project: z
+          .string()
+          .optional()
+          .describe(
+            'Filter applications by ArgoCD project name (exact match, applied server-side by the ArgoCD API). Use list_projects to discover project names. Optional.'
+          ),
+        destCluster: z
+          .string()
+          .optional()
+          .describe(
+            'Filter applications by destination cluster, accepting either a cluster name (e.g. "in-cluster") or an API server URL (e.g. "https://10.0.0.1:6443"). The identifier is resolved against the registered clusters, so applications that reference their destination by the other identifier are matched too. Applied before pagination. Use list_clusters to discover cluster names and server URLs. Optional.'
+          ),
         limit: z
           .number()
           .int()
@@ -93,9 +105,11 @@ export class Server extends McpServer {
             'Number of applications to skip before returning results. Use with limit for pagination. Optional.'
           )
       },
-      async ({ search, limit, offset }, client) =>
+      async ({ search, project, destCluster, limit, offset }, client) =>
         await client.listApplications({
           search: search ?? undefined,
+          project: project ?? undefined,
+          destCluster: destCluster ?? undefined,
           limit,
           offset
         })
@@ -130,6 +144,12 @@ export class Server extends McpServer {
         projectName: z.string().describe('The name of the ArgoCD AppProject to fetch.')
       },
       async ({ projectName }, client) => await client.getAppProject(projectName)
+    );
+    this.addJsonOutputTool(
+      'list_projects',
+      'list_projects returns the list of ArgoCD AppProjects with their name, description, source repositories and allowed destinations (clusters/namespaces). Use it to discover which projects exist and which clusters they may deploy to; use get_appproject for the full details of a single project.',
+      {},
+      async (_args, client) => await client.listProjects()
     );
     this.addJsonOutputTool(
       'get_application_resource_tree',

--- a/src/types/argocd-types.ts
+++ b/src/types/argocd-types.ts
@@ -14,3 +14,4 @@ export type V1alpha1ApplicationResourceResult = ArgoCD.ApplicationApplicationRes
 export type V1alpha1Cluster = ArgoCD.V1alpha1Cluster;
 export type V1alpha1ClusterList = ArgoCD.V1alpha1ClusterList;
 export type V1alpha1AppProject = ArgoCD.V1alpha1AppProject;
+export type V1alpha1AppProjectList = ArgoCD.V1alpha1AppProjectList;


### PR DESCRIPTION
## Motivation

On large ArgoCD installations (ours has ~1400 applications across dozens of clusters) `list_applications` is hard for an LLM client to use: the only filter is `search` (name substring), so a routine question like *"which applications are deployed to cluster X"* forces the model to paginate through the entire installation, and each page is heavy enough to blow through MCP clients' response-size limits.

## Changes

- **`list_applications`: new optional `project` argument** — passed to the ArgoCD API as the server-side `projects` query parameter.
- **`list_applications`: new optional `destCluster` argument** — accepts either a cluster name or an API server URL. The identifier is resolved against the registered clusters (`/api/v1/clusters`) and expanded with the other identifier, because applications may reference their destination via `spec.destination.name` OR `spec.destination.server`; both spellings are then matched. Applied after field stripping and before pagination, so `totalItems`/`hasMore` reflect the filtered set. Falls back to exact matching on the raw identifier if clusters cannot be listed.
- **New read-only tool `list_projects`** — lists AppProjects stripped down to name, description, sourceRepos and destinations. Complements the existing `get_appproject` and gives clients a cheap way to discover project names for the `project` filter.
- **Slimmer `list_applications` items** — following the existing "strip heavy fields" approach: drop `status.sync.comparedTo` (a full copy of source + destination), `status.summary` (image/URL lists) and helm/kustomize parameters from `spec.source` (kept: `repoURL`, `path`, `chart`, `targetRevision`). A list item shrinks from ~1 KB to ~300–600 bytes; `get_application` still returns the complete resource.

## Testing

- Unit tests added for the destination matcher and the new tool registration (incl. read-only mode); `pnpm build` / `pnpm test` (30 pass) / `pnpm lint` are green.
- End-to-end tested over streamable HTTP against a stub ArgoCD API and against a production installation: `destCluster` returns the same set whether given the cluster name or its server URL; applications of a neighbouring cluster are not matched; pagination metadata reflects the filtered set.

Both commits are DCO signed off.
