### PR TITLE
feat: add refresh option to get_application

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The server provides the following ArgoCD management tools:
 
 ### Application Management
 - `list_applications`: List and filter all applications
-- `get_application`: Get detailed information about a specific application
+- `get_application`: Get detailed information about a specific application. Accepts an optional `refresh` (`normal` or `hard`) to reconcile the application against its source before returning; `hard` also re-generates manifests from the source repository, equivalent to "Hard Refresh" in the UI
 - `create_application`: Create a new application
 - `update_application`: Update an existing application
 - `delete_application`: Delete an application

--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -80,11 +80,18 @@ export class ArgoCDClient {
     return body;
   }
 
-  public async getApplication(applicationName: string, appNamespace?: string) {
-    const queryParams = appNamespace ? { appNamespace } : undefined;
+  public async getApplication(
+    applicationName: string,
+    appNamespace?: string,
+    refresh?: 'normal' | 'hard'
+  ) {
+    const queryParams = {
+      ...(appNamespace && { appNamespace }),
+      ...(refresh && { refresh })
+    };
     const { body } = await this.client.get<V1alpha1Application>(
       `/api/v1/applications/${applicationName}`,
-      queryParams
+      Object.keys(queryParams).length > 0 ? queryParams : undefined
     );
     return body;
   }

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -175,3 +175,92 @@ test('with no default token, an overridden URL still resolves only from the regi
   assert.equal(result.isError, true);
   assert.match(textOf(result), /Missing required ArgoCD API token/);
 });
+
+// The tests below cover the query-string contract of get_application's `refresh`
+// argument: it must reach the ArgoCD REST API as a query parameter, and must be
+// absent when the caller omits it so that existing behaviour is unchanged.
+// global fetch is stubbed, so these remain hermetic (no network).
+
+const serverWithDefaults = () =>
+  createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry()
+  });
+
+// Run fn with a stubbed global fetch and return every URL it was called with.
+const captureFetchUrls = async (fn: () => Promise<void>): Promise<string[]> => {
+  const urls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+    urls.push(String(input));
+    return new Response(JSON.stringify({ metadata: { name: 'my-app' } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }) as typeof fetch;
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  return urls;
+};
+
+test('get_application forwards refresh=hard as a query parameter', async () => {
+  const server = serverWithDefaults();
+  let result: { isError?: boolean; content: { text: string }[] } | undefined;
+
+  const urls = await captureFetchUrls(async () => {
+    result = await callTool(server, 'get_application', {
+      applicationName: 'my-app',
+      refresh: 'hard'
+    });
+  });
+
+  assert.equal(result?.isError, false);
+  assert.equal(urls.length, 1);
+  assert.equal(new URL(urls[0]).searchParams.get('refresh'), 'hard');
+});
+
+test('get_application forwards refresh=normal as a query parameter', async () => {
+  const server = serverWithDefaults();
+
+  const urls = await captureFetchUrls(async () => {
+    await callTool(server, 'get_application', {
+      applicationName: 'my-app',
+      refresh: 'normal'
+    });
+  });
+
+  assert.equal(urls.length, 1);
+  assert.equal(new URL(urls[0]).searchParams.get('refresh'), 'normal');
+});
+
+test('get_application omits the refresh query parameter when it is not requested', async () => {
+  const server = serverWithDefaults();
+
+  const urls = await captureFetchUrls(async () => {
+    await callTool(server, 'get_application', { applicationName: 'my-app' });
+  });
+
+  assert.equal(urls.length, 1);
+  assert.equal(new URL(urls[0]).searchParams.has('refresh'), false);
+});
+
+test('get_application sends appNamespace and refresh together', async () => {
+  const server = serverWithDefaults();
+
+  const urls = await captureFetchUrls(async () => {
+    await callTool(server, 'get_application', {
+      applicationName: 'my-app',
+      applicationNamespace: 'argocd',
+      refresh: 'hard'
+    });
+  });
+
+  assert.equal(urls.length, 1);
+  const params = new URL(urls[0]).searchParams;
+  assert.equal(params.get('appNamespace'), 'argocd');
+  assert.equal(params.get('refresh'), 'hard');
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -115,13 +115,19 @@ export class Server extends McpServer {
     );
     this.addJsonOutputTool(
       'get_application',
-      'get_application returns application by application name. Optionally specify the application namespace to get applications from non-default namespaces.',
+      'get_application returns application by application name. Optionally specify the application namespace to get applications from non-default namespaces. Optionally request a refresh to reconcile the application against its source before returning.',
       {
         applicationName: z.string(),
-        applicationNamespace: ApplicationNamespaceSchema.optional()
+        applicationNamespace: ApplicationNamespaceSchema.optional(),
+        refresh: z
+          .enum(['normal', 'hard'])
+          .optional()
+          .describe(
+            'Refresh the application before returning it. "normal" re-compares live state against the cached manifests; "hard" additionally discards the cached manifests and re-generates them from the source repository (equivalent to "Hard Refresh" in the ArgoCD UI). Use "hard" when the rendered manifests may be stale — for example with config management plugins whose output is not a pure function of the Git revision. Omit to return the application without refreshing.'
+          )
       },
-      async ({ applicationName, applicationNamespace }, client) =>
-        await client.getApplication(applicationName, applicationNamespace)
+      async ({ applicationName, applicationNamespace, refresh }, client) =>
+        await client.getApplication(applicationName, applicationNamespace, refresh)
     );
     this.addJsonOutputTool(
       'get_appproject',


### PR DESCRIPTION
## Summary

Adds an optional `refresh` argument (`normal` | `hard`) to the `get_application` tool, forwarded to the ArgoCD API as a query parameter on `GET /api/v1/applications/{name}`.

ArgoCD exposes refresh only as a query parameter on GET operations — there is no refresh endpoint — and the server did not forward it, so no tool could trigger a refresh at all. `sync_application` exists with no read-side counterpart.

This matters where the rendered manifests are not a pure function of the Git revision, for example a config management plugin that resolves an image tag at render time. ArgoCD may then serve a cached manifest set, so a sync reports `Succeeded` and the application reports `Synced` while a stale render was actually applied. The drift is not visible until someone hard refreshes. Without this parameter an MCP client has no way to establish that what it is reading, or about to sync, is current.

## Changes

- **`src/argocd/client.ts`** — `getApplication()` accepts an optional `refresh` and includes it in the query params, following the existing `listClusters` / `getApplicationManagedResources` pattern of building an object and passing `undefined` when it is empty.
- **`src/server/server.ts`** — register `refresh` on `get_application` as an optional `z.enum(['normal', 'hard'])`, with guidance in the description on when `hard` is needed.
- **`src/server/server.test.ts`** — cover `hard`, `normal`, omission, and combination with `appNamespace`.
- **`README.md`** — document the argument on the `get_application` entry.

## Behavior notes

- `refresh` stays in the always-on read/query block rather than behind the `if (!isReadOnly)` gate, matching how ArgoCD models it: a `GET` requiring only `applications, get` RBAC. It therefore remains available when `MCP_READ_ONLY=true`.
- Omitting `refresh` sends no `refresh` query parameter, so the outgoing request is identical to before. This is asserted explicitly rather than left implicit.
- No changes to `src/types/argocd-types.ts` were needed; the response shape is the existing `V1alpha1Application`.

## Testing

- `pnpm lint` — clean
- `pnpm test` — 26/26 pass (4 new)
- `pnpm build` — clean
- `GET /api/v1/applications/{name}?refresh=hard` verified against a live ArgoCD instance

The new tests stub `globalThis.fetch` and restore it in a `finally`. Tests within a file run sequentially, so the stub cannot leak into the existing token-resolution tests, which stay hermetic by never reaching HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
