### PR TITLE
feat: add opt-in JWT verification for inbound requests (identity-aware proxy support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,23 @@ This will disable the following tools:
 
 By default, all the tools will be available.
 
+### Inbound Request Authentication
+
+By default the HTTP/SSE endpoints accept unauthenticated requests. If the server runs behind an identity-aware proxy (Cloudflare Access, Google IAP, oauth2-proxy, ...) that authenticates users at the edge and forwards a signed JWT, the server can verify that JWT on every inbound MCP request — so requests that bypass the proxy and hit the port directly are rejected with `401`.
+
+Enable it by setting all of:
+
+| Variable | Meaning |
+| --- | --- |
+| `MCP_AUTH_JWKS_URL` | JWKS endpoint of the token issuer, e.g. `https://<team>.cloudflareaccess.com/cdn-cgi/access/certs` |
+| `MCP_AUTH_ISSUER` | Expected `iss` claim, e.g. `https://<team>.cloudflareaccess.com` |
+| `MCP_AUTH_AUDIENCE` | Expected `aud` claim (the proxy application's audience tag) |
+| `MCP_AUTH_TOKEN_HEADER` | Optional. Header carrying the JWT. Defaults to `authorization` (Bearer scheme); Cloudflare Access sends `cf-access-jwt-assertion` |
+
+Tokens are verified: RS256 signature against the JWKS, plus the `iss`, `aud` and `exp` claims. `/healthz` stays open for Kubernetes probes.
+
+By default (no `MCP_AUTH_*` variables set), inbound requests are not authenticated. Setting only some of the required variables is a misconfiguration: the server fails at startup instead of silently running unauthenticated.
+
 ### Stateless Mode
 
 By default, the HTTP transport assigns a session ID to each client connection and keeps an in-memory map of active sessions. This works well for single-instance deployments but causes `400` errors when multiple replicas are running without sticky sessions, because a request routed to a different pod will not find the session that was created on the original pod.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "jose": "^6.2.8",
     "pino": "^9.6.0",
     "yargs": "^17.7.2",
     "zod": "^3.25.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      jose:
+        specifier: ^6.2.8
+        version: 6.2.8
       pino:
         specifier: ^9.6.0
         version: 9.6.0
@@ -267,7 +270,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==, tarball: https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz}
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -315,7 +318,7 @@ packages:
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
   '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==, tarball: https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz}
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -378,56 +381,67 @@ packages:
     resolution: {integrity: sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.40.0':
     resolution: {integrity: sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.40.0':
     resolution: {integrity: sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.40.0':
     resolution: {integrity: sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.40.0':
     resolution: {integrity: sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.40.0':
     resolution: {integrity: sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.40.0':
     resolution: {integrity: sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.40.0':
     resolution: {integrity: sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.40.0':
     resolution: {integrity: sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.40.0':
     resolution: {integrity: sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.40.0':
     resolution: {integrity: sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.40.0':
     resolution: {integrity: sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==}
@@ -555,7 +569,7 @@ packages:
     engines: {node: '>= 14'}
 
   ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==, tarball: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz}
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -566,7 +580,7 @@ packages:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==, tarball: https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz}
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -602,7 +616,7 @@ packages:
     engines: {node: '>=18'}
 
   body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==, tarball: https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz}
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   brace-expansion@1.1.12:
@@ -692,7 +706,7 @@ packages:
     engines: {node: '>= 0.6'}
 
   cors@2.8.5:
-    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==, tarball: https://registry.npmjs.org/cors/-/cors-2.8.5.tgz}
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
 
   cross-fetch@4.1.0:
@@ -712,7 +726,7 @@ packages:
         optional: true
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==, tarball: https://registry.npmjs.org/debug/-/debug-4.4.3.tgz}
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -851,15 +865,15 @@ packages:
     engines: {node: '>= 0.6'}
 
   eventsource-parser@3.0.1:
-    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==, tarball: https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz}
+    resolution: {integrity: sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.6:
-    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==, tarball: https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz}
+    resolution: {integrity: sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==}
     engines: {node: '>=18.0.0'}
 
   express-rate-limit@8.4.0:
-    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==, tarball: https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz}
+    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -869,7 +883,7 @@ packages:
     engines: {node: '>= 18'}
 
   express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==, tarball: https://registry.npmjs.org/express/-/express-5.2.1.tgz}
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
@@ -893,7 +907,7 @@ packages:
     engines: {node: '>=6'}
 
   fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==, tarball: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz}
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1000,7 +1014,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==, tarball: https://registry.npmjs.org/hono/-/hono-4.12.14.tgz}
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.0:
@@ -1008,7 +1022,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==, tarball: https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz}
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
@@ -1024,7 +1038,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==, tarball: https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz}
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -1043,7 +1057,7 @@ packages:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==, tarball: https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz}
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1075,8 +1089,8 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jose@6.2.2:
-    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==, tarball: https://registry.npmjs.org/jose/-/jose-6.2.2.tgz}
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1093,10 +1107,10 @@ packages:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz}
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==, tarball: https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz}
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1277,7 +1291,7 @@ packages:
     engines: {node: '>= 6'}
 
   pkce-challenge@5.0.0:
-    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==, tarball: https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz}
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
 
   postcss-load-config@6.0.1:
@@ -1327,7 +1341,7 @@ packages:
     engines: {node: '>=0.6'}
 
   qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.1.tgz}
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -1345,7 +1359,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==, tarball: https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz}
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
   readdirp@4.1.2:
@@ -1361,7 +1375,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==, tarball: https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz}
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
@@ -1461,7 +1475,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==, tarball: https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz}
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   string-width@4.2.3:
@@ -1651,12 +1665,12 @@ packages:
     engines: {node: '>=10'}
 
   zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==, tarball: https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz}
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
 
   zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==, tarball: https://registry.npmjs.org/zod/-/zod-3.25.76.tgz}
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -1840,7 +1854,7 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.4.0(express@5.2.1)
       hono: 4.12.14
-      jose: 6.2.2
+      jose: 6.2.8
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
@@ -2673,7 +2687,7 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jose@6.2.2: {}
+  jose@6.2.8: {}
 
   joycon@3.1.1: {}
 

--- a/src/server/auth.test.ts
+++ b/src/server/auth.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { generateKeyPair, SignJWT, JWTVerifyGetKey } from 'jose';
+import { Request, Response } from 'express';
+import { AuthConfig, authConfigFromEnv, createAuthMiddleware } from './auth.js';
+
+const ISSUER = 'https://team.cloudflareaccess.com';
+const AUDIENCE = 'test-audience-tag';
+const HEADER = 'cf-access-jwt-assertion';
+
+const config: AuthConfig = {
+  jwksUrl: 'https://team.cloudflareaccess.com/cdn-cgi/access/certs',
+  issuer: ISSUER,
+  audience: AUDIENCE,
+  header: HEADER
+};
+
+// One signing key pair for the suite; `getKey` stands in for the remote JWKS.
+const keys = await generateKeyPair('RS256');
+const getKey: JWTVerifyGetKey = async () => keys.publicKey;
+
+const signToken = async (
+  overrides: {
+    issuer?: string;
+    audience?: string;
+    expiresIn?: string | number;
+    omitExp?: boolean;
+    key?: CryptoKey;
+  } = {}
+): Promise<string> => {
+  const jwt = new SignJWT({ email: 'user@example.com' })
+    .setProtectedHeader({ alg: 'RS256' })
+    .setIssuer(overrides.issuer ?? ISSUER)
+    .setAudience(overrides.audience ?? AUDIENCE);
+  if (!overrides.omitExp) jwt.setExpirationTime(overrides.expiresIn ?? '5m');
+  return jwt.sign(overrides.key ?? keys.privateKey);
+};
+
+// Minimal req/res doubles; run the middleware and report what it did.
+const run = async (
+  headers: Record<string, string>,
+  middlewareConfig: AuthConfig = config
+): Promise<{ nextCalled: boolean; status: number | null }> => {
+  const req = { headers, method: 'POST', path: '/mcp' } as unknown as Request;
+  let status: number | null = null;
+  let nextCalled = false;
+  const res = {
+    status(code: number) {
+      status = code;
+      return this;
+    },
+    send() {
+      return this;
+    }
+  } as unknown as Response;
+  await createAuthMiddleware(middlewareConfig, getKey)(req, res, () => {
+    nextCalled = true;
+  });
+  return { nextCalled, status };
+};
+
+// --- Middleware: accept/reject ---------------------------------------------
+
+test('accepts a valid token', async () => {
+  const result = await run({ [HEADER]: await signToken() });
+  assert.equal(result.nextCalled, true);
+  assert.equal(result.status, null);
+});
+
+test('rejects a request without the token header', async () => {
+  const result = await run({});
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.status, 401);
+});
+
+test('rejects a token signed by a different key', async () => {
+  const otherKeys = await generateKeyPair('RS256');
+  const result = await run({ [HEADER]: await signToken({ key: otherKeys.privateKey }) });
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.status, 401);
+});
+
+test('rejects a token with the wrong audience', async () => {
+  const result = await run({ [HEADER]: await signToken({ audience: 'another-app' }) });
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.status, 401);
+});
+
+test('rejects a token with the wrong issuer', async () => {
+  const result = await run({
+    [HEADER]: await signToken({ issuer: 'https://evil.example.com' })
+  });
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.status, 401);
+});
+
+test('rejects an expired token', async () => {
+  const result = await run({ [HEADER]: await signToken({ expiresIn: '-5m' }) });
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.status, 401);
+});
+
+test('rejects a token without an exp claim', async () => {
+  const result = await run({ [HEADER]: await signToken({ omitExp: true }) });
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.status, 401);
+});
+
+test('rejects an unsigned alg=none token with valid-looking claims', async () => {
+  const b64 = (obj: object) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  const forged = `${b64({ alg: 'none' })}.${b64({
+    iss: ISSUER,
+    aud: AUDIENCE,
+    exp: Math.floor(Date.now() / 1000) + 300,
+    email: 'attacker@example.com'
+  })}.`;
+  const result = await run({ [HEADER]: forged });
+  assert.equal(result.nextCalled, false);
+  assert.equal(result.status, 401);
+});
+
+test('strips the Bearer prefix when using the authorization header', async () => {
+  const bearerConfig = { ...config, header: 'authorization' };
+  const result = await run({ authorization: `Bearer ${await signToken()}` }, bearerConfig);
+  assert.equal(result.nextCalled, true);
+});
+
+// --- authConfigFromEnv ------------------------------------------------------
+
+test('authConfigFromEnv returns null when no auth vars are set', () => {
+  assert.equal(authConfigFromEnv({}), null);
+});
+
+test('authConfigFromEnv parses a full config and defaults the header', () => {
+  const parsed = authConfigFromEnv({
+    MCP_AUTH_JWKS_URL: config.jwksUrl,
+    MCP_AUTH_ISSUER: ISSUER,
+    MCP_AUTH_AUDIENCE: AUDIENCE
+  });
+  assert.deepEqual(parsed, { ...config, header: 'authorization' });
+});
+
+test('authConfigFromEnv lowercases a custom header', () => {
+  const parsed = authConfigFromEnv({
+    MCP_AUTH_JWKS_URL: config.jwksUrl,
+    MCP_AUTH_ISSUER: ISSUER,
+    MCP_AUTH_AUDIENCE: AUDIENCE,
+    MCP_AUTH_TOKEN_HEADER: 'CF-Access-Jwt-Assertion'
+  });
+  assert.equal(parsed?.header, 'cf-access-jwt-assertion');
+});
+
+test('authConfigFromEnv fails closed on partial config', () => {
+  assert.throws(
+    () => authConfigFromEnv({ MCP_AUTH_JWKS_URL: config.jwksUrl }),
+    /missing MCP_AUTH_ISSUER, MCP_AUTH_AUDIENCE/
+  );
+});

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,84 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { createRemoteJWKSet, jwtVerify, JWTVerifyGetKey } from 'jose';
+import { logger } from '../logging/logging.js';
+
+// Opt-in verification of a JWT on every inbound MCP request. Intended for
+// deployments behind an identity-aware proxy (Cloudflare Access, Google IAP,
+// oauth2-proxy, ...) that authenticates the user at the edge and forwards a
+// signed identity assertion in a header.
+
+export type AuthConfig = {
+  jwksUrl: string;
+  issuer: string;
+  audience: string;
+  header: string;
+};
+
+// Clock-skew tolerance in seconds.
+const CLOCK_TOLERANCE = 10;
+
+// Read the auth config from the environment. All vars set: auth is enforced.
+// None set: no auth. Partially set: throws an error, so a half-configured
+// deployment fails at startup instead of silently running unauthenticated.
+export const authConfigFromEnv = (env: NodeJS.ProcessEnv = process.env): AuthConfig | null => {
+  const jwksUrl = env.MCP_AUTH_JWKS_URL?.trim() || '';
+  const issuer = env.MCP_AUTH_ISSUER?.trim() || '';
+  const audience = env.MCP_AUTH_AUDIENCE?.trim() || '';
+  const header = (env.MCP_AUTH_TOKEN_HEADER?.trim() || 'authorization').toLowerCase();
+
+  if (!jwksUrl && !issuer && !audience) return null;
+
+  const missing = [
+    ['MCP_AUTH_JWKS_URL', jwksUrl],
+    ['MCP_AUTH_ISSUER', issuer],
+    ['MCP_AUTH_AUDIENCE', audience]
+  ]
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+  if (missing.length > 0) {
+    throw new Error(`Incomplete inbound auth config: missing ${missing.join(', ')}`);
+  }
+
+  return { jwksUrl, issuer, audience, header };
+};
+
+const extractToken = (req: Request, header: string): string => {
+  const raw = req.headers[header];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (!value) return '';
+  return header === 'authorization' ? value.replace(/^Bearer\s+/i, '') : value;
+};
+
+export const createAuthMiddleware = (
+  config: AuthConfig,
+  getKey?: JWTVerifyGetKey
+): RequestHandler => {
+  const keySource = getKey ?? createRemoteJWKSet(new URL(config.jwksUrl));
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const token = extractToken(req, config.header);
+    if (!token) {
+      res.status(401).send(`Unauthorized: missing token in "${config.header}" header`);
+      return;
+    }
+
+    try {
+      const { payload } = await jwtVerify(token, keySource, {
+        issuer: config.issuer,
+        audience: config.audience,
+        algorithms: ['RS256'],
+        clockTolerance: CLOCK_TOLERANCE,
+        requiredClaims: ['exp']
+      });
+      logger.debug(
+        `authenticated request: ${payload.email ?? payload.sub ?? 'unknown'} ${req.method} ${req.path}`
+      );
+      next();
+    } catch (error) {
+      logger.warn(
+        `rejected inbound token: ${error instanceof Error ? error.name : 'unknown error'}`
+      );
+      res.status(401).send('Unauthorized: invalid token');
+    }
+  };
+};

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'node:crypto';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { tokenRegistryFromEnv } from './tokenRegistry.js';
+import { authConfigFromEnv, createAuthMiddleware } from './auth.js';
 
 // Load the base-URL -> token registry once at startup from the JSON file at
 // ARGOCD_TOKEN_REGISTRY_PATH. Shared across all connections; read-only after
@@ -24,8 +25,18 @@ export const connectStdioTransport = () => {
   server.connect(new StdioServerTransport());
 };
 
+// Enforce inbound JWT auth on MCP routes when configured (MCP_AUTH_* env
+// vars). /healthz stays open for Kubernetes probes.
+const applyInboundAuth = (app: express.Express, paths: string[]) => {
+  const authConfig = authConfigFromEnv();
+  if (!authConfig) return;
+  app.use(paths, createAuthMiddleware(authConfig));
+  logger.info(`Inbound JWT auth enabled on ${paths.join(', ')} (header: ${authConfig.header})`);
+};
+
 export const connectSSETransport = (port: number) => {
   const app = express();
+  applyInboundAuth(app, ['/sse', '/messages']);
   const transports: { [sessionId: string]: SSEServerTransport } = {};
 
   app.get('/sse', async (req, res) => {
@@ -97,6 +108,8 @@ export const connectHttpTransport = (port: number, stateless = false) => {
   app.get('/healthz', (_, res) => {
     res.status(200).json({ status: 'ok' });
   });
+
+  applyInboundAuth(app, ['/mcp']);
 
   const httpTransports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
 


### PR DESCRIPTION
## Summary

Deployments often run this server behind an identity-aware proxy (Cloudflare Access, Google IAP, oauth2-proxy, ...) that authenticates users at the edge and forwards a signed JWT in a header. The server itself, however, accepts unauthenticated requests — anyone who can reach the port directly (e.g. another pod in the same cluster, bypassing the proxy) can call the MCP endpoint and use the server's ArgoCD credentials.

This PR adds opt-in verification of that JWT on every inbound MCP request:

- Enabled by setting `MCP_AUTH_JWKS_URL`, `MCP_AUTH_ISSUER`, `MCP_AUTH_AUDIENCE` (+ optional `MCP_AUTH_TOKEN_HEADER`, default `authorization` Bearer; Cloudflare Access sends `cf-access-jwt-assertion`).
- Tokens are verified: RS256 signature against the issuer's JWKS (fetched and cached via `jose`), plus `iss`, `aud` and `exp`.
- Applied to `/mcp` (HTTP) and `/sse` + `/messages` (SSE); `/healthz` stays open for probes.
- No env vars set → behavior unchanged. Partial config → fail closed at startup.

## Test plan

- [x] `npm run lint`, `npm run build`
- [x] `npm test` (35 passing — accept/reject paths incl. wrong key/aud/iss, expired, missing exp, forged `alg=none` token, Bearer stripping, fail-closed config)
- [x] Manual: server with auth enabled → no token 401, forged token 401, `/healthz` 200; without auth env → unchanged