### PR TITLE
feat: support binding HTTP/SSE transports to a specific host (--host / LISTEN_HOST)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,18 @@ In stateless mode:
 
 This mode is recommended for Kubernetes deployments with Horizontal Pod Autoscaling (HPA) where network-level sticky sessions are not available.
 
+### Bind Host
+
+By default, the `http` and `sse` transports listen on all network interfaces. To restrict which interface the server binds to, pass the `--host` flag or set the `LISTEN_HOST` environment variable:
+
+```bash
+node dist/index.js http --host 127.0.0.1
+# or
+LISTEN_HOST=127.0.0.1 node dist/index.js http
+```
+
+Binding to `127.0.0.1` makes the server reachable only from the same host (or the same pod when run as a Kubernetes sidecar). Note that a loopback-bound server is not reachable by Kubernetes `httpGet` probes, which connect via the pod IP — use an `exec` probe instead.
+
 ## For Development
 
 1. Clone the repository:

--- a/src/cmd/cmd.ts
+++ b/src/cmd/cmd.ts
@@ -20,12 +20,21 @@ export const cmd = () => {
     'sse',
     'Start ArgoCD MCP server using SSE.',
     (yargs) => {
-      return yargs.option('port', {
-        type: 'number',
-        default: 3000
-      });
+      return yargs
+        .option('port', {
+          type: 'number',
+          default: 3000
+        })
+        .option('host', {
+          type: 'string',
+          default: process.env.LISTEN_HOST ?? '',
+          description:
+            'Host/interface to bind to, e.g. 127.0.0.1 (env: LISTEN_HOST; default: all interfaces)'
+        });
     },
-    ({ port }) => connectSSETransport(port)
+    ({ port, host }) => {
+      connectSSETransport(port, host || undefined);
+    }
   );
 
   exe.command(
@@ -41,9 +50,17 @@ export const cmd = () => {
           type: 'boolean',
           default: false,
           description: 'Run in stateless mode'
+        })
+        .option('host', {
+          type: 'string',
+          default: process.env.LISTEN_HOST ?? '',
+          description:
+            'Host/interface to bind to, e.g. 127.0.0.1 (env: LISTEN_HOST; default: all interfaces)'
         });
     },
-    ({ port, stateless }) => connectHttpTransport(port, stateless)
+    ({ port, stateless, host }) => {
+      connectHttpTransport(port, stateless, host || undefined);
+    }
   );
 
   exe.demandCommand().parseSync();

--- a/src/server/transport.test.ts
+++ b/src/server/transport.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { connectHttpTransport } from './transport.js';
+
+const listening = (server: Server) =>
+  new Promise<AddressInfo>((resolve) =>
+    server.once('listening', () => resolve(server.address() as AddressInfo))
+  );
+
+const closed = (server: Server) => new Promise((resolve) => server.close(resolve));
+
+test('http transport binds all interfaces by default', async () => {
+  const server = connectHttpTransport(0);
+  const { address, port } = await listening(server);
+  assert.notStrictEqual(address, '127.0.0.1');
+  const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+  assert.strictEqual(res.status, 200);
+  await closed(server);
+});
+
+test('http transport binds only the given host', async () => {
+  const server = connectHttpTransport(0, false, '127.0.0.1');
+  const { address, port } = await listening(server);
+  assert.strictEqual(address, '127.0.0.1');
+  const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+  assert.strictEqual(res.status, 200);
+  await closed(server);
+});

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -24,7 +24,7 @@ export const connectStdioTransport = () => {
   server.connect(new StdioServerTransport());
 };
 
-export const connectSSETransport = (port: number) => {
+export const connectSSETransport = (port: number, host?: string) => {
   const app = express();
   const transports: { [sessionId: string]: SSEServerTransport } = {};
 
@@ -53,8 +53,8 @@ export const connectSSETransport = (port: number) => {
     }
   });
 
-  logger.info(`Connecting to SSE transport on port: ${port}`);
-  app.listen(port);
+  logger.info(`Connecting to SSE transport on port: ${port}${host ? ` (host: ${host})` : ''}`);
+  return host ? app.listen(port, host) : app.listen(port);
 };
 
 // Resolve the session-level ArgoCD credentials from headers or env.
@@ -90,7 +90,7 @@ const resolveCredentials = (
   return { argocdBaseUrl, argocdApiToken };
 };
 
-export const connectHttpTransport = (port: number, stateless = false) => {
+export const connectHttpTransport = (port: number, stateless = false, host?: string) => {
   const app = express();
   app.use(express.json());
 
@@ -161,7 +161,7 @@ export const connectHttpTransport = (port: number, stateless = false) => {
   app.delete('/mcp', handleSessionRequest);
 
   logger.info(
-    `Connecting to Http Stream transport on port: ${port}${stateless ? ' (stateless mode)' : ''}`
+    `Connecting to Http Stream transport on port: ${port}${stateless ? ' (stateless mode)' : ''}${host ? ` (host: ${host})` : ''}`
   );
-  app.listen(port);
+  return host ? app.listen(port, host) : app.listen(port);
 };


### PR DESCRIPTION
## Summary

The `http` and `sse` transports currently call `app.listen(port)` with no way to choose the bind interface, so the server always listens on all interfaces. This PR adds an optional `--host` flag (env fallback: `LISTEN_HOST`) to both commands.

Main use case: running the server as a Kubernetes sidecar bound to `127.0.0.1`, so it is only reachable by containers in the same pod (e.g. an auth proxy) and not from the pod network.

## Changes

- `--host` option on the `sse` and `http` commands, falling back to the `LISTEN_HOST` env var
- `connectSSETransport` / `connectHttpTransport` accept an optional `host`, pass it to `listen()`, and return the `http.Server` (used by the new tests)
- Tests covering the default (all interfaces) and loopback-only binding
- README section documenting the flag, including the `httpGet`-probe caveat for loopback binding

## Compatibility

Non-breaking: with `--host`/`LISTEN_HOST` unset, `listen()` is called exactly as before (all interfaces).