### PR TITLE
feat: Add username/password authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ This token is **outbound only**: it authenticates this server to ArgoCD and neve
 
 This is the **default token**. It is **mandatory unless a [token registry](#token-registry--per-base-url-tokens-multi-instance) is configured**: on the HTTP transport, a connection that supplies no token (neither header nor env var) is rejected with `400 Bad Request`, but when a registry is configured a tokenless connection is allowed because each call resolves its own [registry token](#two-kinds-of-token). Keeping the token out of tool arguments ensures it never enters prompts, model context, or tool-call logs.
 
+#### Username/password — alternative to an API token
+
+If you don't have (or don't want to use) an API token, supply a username and password instead and the server logs in to ArgoCD's `/api/v1/session` endpoint for you:
+
+- **HTTP headers** (HTTP transport only): `x-argocd-username` / `x-argocd-password`.
+- **Environment variables**: `ARGOCD_USERNAME` / `ARGOCD_PASSWORD` (all transports).
+
+This requires a base URL to be known at connect time (`x-argocd-base-url` header or `ARGOCD_BASE_URL` env var) — the login request has to go somewhere. The resulting session token is used exactly like `ARGOCD_API_TOKEN` for the rest of the session, and is **not refreshed**: ArgoCD's session tokens expire (24h by default), so a session that outlives that window needs a fresh connection. An API token, when present, always takes priority over username/password.
+
 #### Base URL — header / env var, or per-call argument
 
 The base URL may be supplied at the session level (resolved once when the server starts or when an HTTP client connects):

--- a/src/argocd/http.ts
+++ b/src/argocd/http.ts
@@ -1,3 +1,27 @@
+// Exchange a username/password for a session token via ArgoCD's login endpoint,
+// so a username/password credential can be used everywhere an API token is
+// (ARGOCD_API_TOKEN, x-argocd-api-token). ArgoCD issues this token with a fixed
+// expiry (24h by default) and it is not refreshed here.
+export const login = async (
+  baseUrl: string,
+  username: string,
+  password: string
+): Promise<string> => {
+  const response = await fetch(new URL('/api/v1/session', baseUrl), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (!response.ok) {
+    throw new Error(`ArgoCD login failed with status ${response.status}`);
+  }
+  const body = (await response.json()) as { token?: string };
+  if (!body.token) {
+    throw new Error('ArgoCD login response did not include a token');
+  }
+  return body.token;
+};
+
 export interface HttpResponse<T> {
   status: number;
   headers: Headers;

--- a/src/cmd/cmd.ts
+++ b/src/cmd/cmd.ts
@@ -79,15 +79,16 @@ const transportOptions = (argv: ListenerArgv): TransportOptions => ({
   allowUnauthenticated: argv.allowUnauthenticated
 });
 
-// resolveListenerSecurity throws on a configuration it cannot honour. Report it as
-// a startup error rather than an unhandled exception stack.
-const start = (run: () => void) => {
-  try {
-    run();
-  } catch (err) {
-    logger.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
-  }
+// resolveListenerSecurity throws on a configuration it cannot honour, and
+// connectStdioTransport's login step can reject. Report either as a startup
+// error rather than an unhandled exception stack.
+const start = (run: () => unknown) => {
+  Promise.resolve()
+    .then(run)
+    .catch((err) => {
+      logger.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    });
 };
 
 export const cmd = () => {
@@ -97,7 +98,7 @@ export const cmd = () => {
     'stdio',
     'Start ArgoCD MCP server using stdio.',
     () => {},
-    () => connectStdioTransport()
+    () => start(() => connectStdioTransport())
   );
 
   exe.command('sse', 'Start ArgoCD MCP server using SSE.', listenerOptions, (argv) =>

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -8,6 +8,7 @@ import type { AddressInfo } from 'node:net';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { tokenRegistryFromEnv } from './tokenRegistry.js';
+import { login } from '../argocd/http.js';
 import {
   applyListenerSecurity,
   resolveListenerSecurity,
@@ -19,10 +20,17 @@ import {
 // construction.
 const tokenRegistry = tokenRegistryFromEnv();
 
-export const connectStdioTransport = () => {
+export const connectStdioTransport = async () => {
+  const argocdBaseUrl = process.env.ARGOCD_BASE_URL || '';
+  const argocdApiToken = await resolveApiToken(
+    argocdBaseUrl,
+    process.env.ARGOCD_API_TOKEN || '',
+    process.env.ARGOCD_USERNAME || '',
+    process.env.ARGOCD_PASSWORD || ''
+  );
   const server = createServer({
-    argocdBaseUrl: process.env.ARGOCD_BASE_URL || '',
-    argocdApiToken: process.env.ARGOCD_API_TOKEN || '',
+    argocdBaseUrl,
+    argocdApiToken,
     tokenRegistry
   });
 
@@ -57,11 +65,33 @@ const listen = (app: express.Express, bindAddress: string, port: number, label: 
   return server;
 };
 
+// A username/password credential is exchanged for a session token once here, so
+// everywhere downstream still only ever deals with a token (ARGOCD_API_TOKEN's
+// shape). Not used when an API token was already supplied — the token wins.
+// Requires a base URL, since the login call has to go somewhere.
+const resolveApiToken = async (
+  argocdBaseUrl: string,
+  argocdApiToken: string,
+  username: string,
+  password: string
+): Promise<string> => {
+  if (argocdApiToken || !username || !password) return argocdApiToken;
+  if (!argocdBaseUrl) {
+    throw new Error(
+      'ARGOCD_BASE_URL (or x-argocd-base-url) is required to log in with a username and password.'
+    );
+  }
+  return login(argocdBaseUrl, username, password);
+};
+
 // Resolve the session-level ArgoCD credentials from headers or env.
 //
 // The API token is only ever accepted here (x-argocd-api-token header or
 // ARGOCD_API_TOKEN env var) — never as a tool-call argument — so the secret
-// stays in the transport layer and out of prompts/model context.
+// stays in the transport layer and out of prompts/model context. A
+// username/password pair (x-argocd-username/x-argocd-password headers or
+// ARGOCD_USERNAME/ARGOCD_PASSWORD env vars) is accepted the same way and
+// exchanged for a token via resolveApiToken.
 //
 // The token is normally MANDATORY and the connection is rejected when it is
 // missing. The exception is when a token registry (ARGOCD_TOKEN_REGISTRY_PATH)
@@ -73,19 +103,32 @@ const listen = (app: express.Express, bindAddress: string, port: number, label: 
 //
 // These are outbound credentials only. Inbound authorization is the listener's
 // job (MCP_AUTH_TOKEN, see security.ts).
-const resolveCredentials = (
+const resolveCredentials = async (
   req: express.Request,
   res: express.Response
-): { argocdBaseUrl: string; argocdApiToken: string } | null => {
+): Promise<{ argocdBaseUrl: string; argocdApiToken: string } | null> => {
   const argocdBaseUrl =
     (req.headers['x-argocd-base-url'] as string) || process.env.ARGOCD_BASE_URL || '';
-  const argocdApiToken =
+  let argocdApiToken =
     (req.headers['x-argocd-api-token'] as string) || process.env.ARGOCD_API_TOKEN || '';
+
+  const username =
+    (req.headers['x-argocd-username'] as string) || process.env.ARGOCD_USERNAME || '';
+  const password =
+    (req.headers['x-argocd-password'] as string) || process.env.ARGOCD_PASSWORD || '';
+  try {
+    argocdApiToken = await resolveApiToken(argocdBaseUrl, argocdApiToken, username, password);
+  } catch (error) {
+    res.status(401).send(error instanceof Error ? error.message : String(error));
+    return null;
+  }
+
   if (!argocdApiToken && tokenRegistry.getSize() === 0) {
     res
       .status(400)
       .send(
         'x-argocd-api-token must be provided in the request header (or the ARGOCD_API_TOKEN env var), ' +
+          'x-argocd-username/x-argocd-password (or ARGOCD_USERNAME/ARGOCD_PASSWORD) must be provided, ' +
           'or a token registry must be configured via ARGOCD_TOKEN_REGISTRY_PATH.'
       );
     return null;
@@ -105,7 +148,7 @@ export const connectSSETransport = (options: TransportOptions) => {
     // Same credential requirement as the http transport. Without it the handler
     // built an McpServer with empty credentials and held it until the socket
     // closed, one per connection.
-    const credentials = resolveCredentials(req, res);
+    const credentials = await resolveCredentials(req, res);
     if (!credentials) return;
     const server = createServer({ ...credentials, tokenRegistry });
 
@@ -149,7 +192,7 @@ export const connectHttpTransport = (options: TransportOptions & { stateless?: b
     if (!stateless && sessionIdFromHeader && httpTransports[sessionIdFromHeader]) {
       transport = httpTransports[sessionIdFromHeader];
     } else if (stateless || (!sessionIdFromHeader && isInitializeRequest(req.body))) {
-      const credentials = resolveCredentials(req, res);
+      const credentials = await resolveCredentials(req, res);
       if (!credentials) return;
 
       transport = new StreamableHTTPServerTransport(


### PR DESCRIPTION
Exchange ARGOCD_USERNAME/ARGOCD_PASSWORD (or x-argocd-username/x-argocd-password headers) for a session token via ArgoCD's login endpoint, as an alternative to ARGOCD_API_TOKEN.