### PR TITLE
feat: support SSO with automatic token refresh via --context flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,13 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.10.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "js-yaml": "^4.1.0",
         "pino": "^9.6.0",
         "yargs": "^17.7.2",
-        "zod": "^3.24.3"
+        "zod": "^3.25.0"
       },
       "bin": {
         "argocd-mcp": "dist/index.js"
@@ -23,6 +24,7 @@
         "@dtsgenerator/replace-namespace": "^1.7.0",
         "@eslint/js": "^9.25.0",
         "@types/express": "^5.0.1",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.14.1",
         "@types/yargs": "^17.0.33",
         "dtsgenerator": "^3.19.2",
@@ -730,11 +732,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1174,6 +1177,13 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1610,8 +1620,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -2990,7 +2999,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "js-yaml": "^4.1.0",
     "pino": "^9.6.0",
     "yargs": "^17.7.2",
     "zod": "^3.25.0"
@@ -70,6 +71,7 @@
     "tsup": "^8.4.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.30.1"
+    "typescript-eslint": "^8.30.1",
+    "@types/js-yaml": "^4.0.9"
   }
 }

--- a/src/argocd/argocdConfig.test.ts
+++ b/src/argocd/argocdConfig.test.ts
@@ -1,0 +1,229 @@
+import assert from 'node:assert/strict';
+import { test, beforeEach, afterEach } from 'node:test';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { dump } from 'js-yaml';
+import { getContextInfo, updateTokensInConfig } from './argocdConfig.js';
+
+// Builds a minimal ArgoCD config YAML with one context + user
+const makeConfig = (opts: {
+  contextName: string;
+  server: string;
+  userName?: string;
+  authToken?: string;
+  refreshToken?: string;
+}): string => {
+  const userName = opts.userName ?? opts.server;
+  return dump({
+    contexts: [{ name: opts.contextName, server: opts.server, user: opts.userName }],
+    users: [
+      {
+        name: userName,
+        'auth-token': opts.authToken,
+        'refresh-token': opts.refreshToken
+      }
+    ]
+  });
+};
+
+let tmpDir: string;
+let configPath: string;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'argocd-config-test-'));
+  configPath = join(tmpDir, 'config');
+  savedEnv = process.env.ARGOCD_CONFIG_HOME;
+  process.env.ARGOCD_CONFIG_HOME = tmpDir;
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) {
+    delete process.env.ARGOCD_CONFIG_HOME;
+  } else {
+    process.env.ARGOCD_CONFIG_HOME = savedEnv;
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// --- getContextInfo ----------------------------------------------------------
+
+test('getContextInfo returns baseUrl, authToken, refreshToken for a valid context', () => {
+  writeFileSync(
+    configPath,
+    makeConfig({
+      contextName: 'my-cluster',
+      server: 'argocd.example.com',
+      authToken: 'tok-abc',
+      refreshToken: 'rt-xyz'
+    })
+  );
+
+  const info = getContextInfo('my-cluster');
+
+  assert.equal(info.server, 'argocd.example.com');
+  assert.equal(info.baseUrl, 'https://argocd.example.com');
+  assert.equal(info.authToken, 'tok-abc');
+  assert.equal(info.refreshToken, 'rt-xyz');
+});
+
+test('getContextInfo returns undefined refreshToken when absent', () => {
+  writeFileSync(
+    configPath,
+    makeConfig({
+      contextName: 'my-cluster',
+      server: 'argocd.example.com',
+      authToken: 'tok-abc'
+    })
+  );
+
+  const info = getContextInfo('my-cluster');
+  assert.equal(info.refreshToken, undefined);
+});
+
+test('getContextInfo uses server as userName when ctx.user is absent', () => {
+  // yaml dump omits undefined keys, so user field won't appear in contexts
+  writeFileSync(
+    configPath,
+    dump({
+      contexts: [{ name: 'ctx', server: 'argocd.example.com' }],
+      users: [{ name: 'argocd.example.com', 'auth-token': 'tok-server-fallback' }]
+    })
+  );
+
+  const info = getContextInfo('ctx');
+  assert.equal(info.authToken, 'tok-server-fallback');
+});
+
+test('getContextInfo throws when context name not found', () => {
+  writeFileSync(
+    configPath,
+    makeConfig({ contextName: 'other', server: 'argocd.example.com', authToken: 'tok' })
+  );
+
+  assert.throws(() => getContextInfo('missing'), /context "missing" not found/);
+});
+
+test('getContextInfo error message includes available context names', () => {
+  writeFileSync(
+    configPath,
+    makeConfig({ contextName: 'prod', server: 'argocd.example.com', authToken: 'tok' })
+  );
+
+  assert.throws(() => getContextInfo('staging'), /prod/);
+});
+
+test('getContextInfo throws when auth-token is absent', () => {
+  writeFileSync(
+    configPath,
+    dump({
+      contexts: [{ name: 'ctx', server: 'argocd.example.com' }],
+      users: [{ name: 'argocd.example.com' }]
+    })
+  );
+
+  assert.throws(() => getContextInfo('ctx'), /No auth-token found/);
+});
+
+test('getContextInfo throws when config file is missing', () => {
+  // No file written — configPath does not exist
+  assert.throws(() => getContextInfo('ctx'), /ENOENT/);
+});
+
+// --- updateTokensInConfig ----------------------------------------------------
+
+test('updateTokensInConfig writes new auth-token to config file', () => {
+  writeFileSync(
+    configPath,
+    makeConfig({
+      contextName: 'my-cluster',
+      server: 'argocd.example.com',
+      authToken: 'old-token'
+    })
+  );
+
+  updateTokensInConfig('my-cluster', 'new-token');
+
+  const info = getContextInfo('my-cluster');
+  assert.equal(info.authToken, 'new-token');
+});
+
+test('updateTokensInConfig also updates refresh-token when provided', () => {
+  writeFileSync(
+    configPath,
+    makeConfig({
+      contextName: 'my-cluster',
+      server: 'argocd.example.com',
+      authToken: 'old-token',
+      refreshToken: 'old-rt'
+    })
+  );
+
+  updateTokensInConfig('my-cluster', 'new-token', 'new-rt');
+
+  const info = getContextInfo('my-cluster');
+  assert.equal(info.authToken, 'new-token');
+  assert.equal(info.refreshToken, 'new-rt');
+});
+
+test('updateTokensInConfig does not clobber refresh-token when new one is absent', () => {
+  writeFileSync(
+    configPath,
+    makeConfig({
+      contextName: 'my-cluster',
+      server: 'argocd.example.com',
+      authToken: 'old-token',
+      refreshToken: 'keep-me'
+    })
+  );
+
+  updateTokensInConfig('my-cluster', 'new-token');
+
+  const info = getContextInfo('my-cluster');
+  assert.equal(info.refreshToken, 'keep-me');
+});
+
+test('updateTokensInConfig write is atomic: file is valid YAML after update', () => {
+  writeFileSync(
+    configPath,
+    makeConfig({
+      contextName: 'my-cluster',
+      server: 'argocd.example.com',
+      authToken: 'old-token'
+    })
+  );
+
+  updateTokensInConfig('my-cluster', 'new-token');
+
+  // File must be readable and parseable after write
+  const content = readFileSync(configPath, 'utf8');
+  assert.ok(content.length > 0);
+  assert.doesNotThrow(() => getContextInfo('my-cluster'));
+});
+
+test('updateTokensInConfig throws when user entry is missing', () => {
+  writeFileSync(
+    configPath,
+    dump({
+      contexts: [{ name: 'ctx', server: 'argocd.example.com' }],
+      users: []
+    })
+  );
+
+  assert.throws(() => updateTokensInConfig('ctx', 'new-token'), /user entry not found/);
+});
+
+// --- ARGOCD_CONFIG_HOME env var ----------------------------------------------
+
+test('ARGOCD_CONFIG_HOME redirects config path', () => {
+  // Config written to tmpDir/config (set in beforeEach via ARGOCD_CONFIG_HOME)
+  writeFileSync(
+    configPath,
+    makeConfig({ contextName: 'ctx', server: 'argocd.example.com', authToken: 'tok' })
+  );
+
+  // Must read from the overridden path, not ~/.config/argocd/config
+  const info = getContextInfo('ctx');
+  assert.equal(info.authToken, 'tok');
+});

--- a/src/argocd/argocdConfig.ts
+++ b/src/argocd/argocdConfig.ts
@@ -1,0 +1,85 @@
+import { readFileSync, writeFileSync, renameSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { load, dump } from 'js-yaml';
+
+const getConfigPath = () =>
+  process.env.ARGOCD_CONFIG_HOME
+    ? join(process.env.ARGOCD_CONFIG_HOME, 'config')
+    : join(homedir(), '.config', 'argocd', 'config');
+
+type ArgocdConfigFile = {
+  contexts?: Array<{ name: string; server: string; user?: string }>;
+  users?: Array<{ name: string; 'auth-token'?: string; 'refresh-token'?: string }>;
+  servers?: Array<{ server: string; [key: string]: unknown }>;
+  'current-context'?: string;
+};
+
+export type ArgocdContextInfo = {
+  server: string;
+  baseUrl: string;
+  authToken: string;
+  refreshToken: string | undefined;
+};
+
+const readConfig = (): ArgocdConfigFile => {
+  const raw = readFileSync(getConfigPath(), 'utf8');
+  return (load(raw) as ArgocdConfigFile) ?? {};
+};
+
+export const getContextInfo = (contextName: string): ArgocdContextInfo => {
+  const config = readConfig();
+
+  const ctx = (config.contexts ?? []).find((c) => c.name === contextName);
+  if (!ctx) {
+    const available = (config.contexts ?? []).map((c) => c.name);
+    throw new Error(
+      `ArgoCD context "${contextName}" not found in ${getConfigPath()}. Available: ${available.join(', ')}`
+    );
+  }
+
+  const userName = ctx.user ?? ctx.server;
+  const user = (config.users ?? []).find((u) => u.name === userName);
+  if (!user?.['auth-token']) {
+    throw new Error(`No auth-token found for context "${contextName}" in ${getConfigPath()}`);
+  }
+
+  return {
+    server: ctx.server,
+    baseUrl: `https://${ctx.server}`,
+    authToken: user['auth-token'],
+    refreshToken: user['refresh-token']
+  };
+};
+
+export const updateTokensInConfig = (
+  contextName: string,
+  newAuthToken: string,
+  newRefreshToken?: string
+): void => {
+  const config = readConfig();
+
+  const ctx = (config.contexts ?? []).find((c) => c.name === contextName);
+  const userName = ctx?.user ?? ctx?.server;
+  const user = (config.users ?? []).find((u) => u.name === userName);
+
+  if (!user) {
+    throw new Error(`Cannot update tokens: user entry not found for context "${contextName}"`);
+  }
+
+  user['auth-token'] = newAuthToken;
+  if (newRefreshToken) {
+    user['refresh-token'] = newRefreshToken;
+  }
+
+  const configPath = getConfigPath();
+  const tmp = `${configPath}.${randomBytes(4).toString('hex')}.tmp`;
+  try {
+    writeFileSync(tmp, dump(config), 'utf8');
+    renameSync(tmp, configPath);
+  } catch (err) {
+    try { renameSync(tmp, `${tmp}.failed`); } catch { /* ignore */ }
+    throw err;
+  }
+};

--- a/src/argocd/client.ts
+++ b/src/argocd/client.ts
@@ -12,6 +12,7 @@ import {
   V1alpha1AppProject
 } from '../types/argocd-types.js';
 import { HttpClient } from './http.js';
+import { decodeJwtPayload } from './jwt.js';
 
 export class ArgoCDClient {
   private baseUrl: string;
@@ -22,6 +23,11 @@ export class ArgoCDClient {
     this.baseUrl = baseUrl;
     this.apiToken = apiToken;
     this.client = new HttpClient(this.baseUrl, this.apiToken);
+  }
+
+  public updateToken(newToken: string): void {
+    this.apiToken = newToken;
+    this.client.updateToken(newToken);
   }
 
   public async listApplications(params?: { search?: string; limit?: number; offset?: number }) {
@@ -92,6 +98,15 @@ export class ArgoCDClient {
   public async getAppProject(projectName: string) {
     const { body } = await this.client.get<V1alpha1AppProject>(`/api/v1/projects/${projectName}`);
     return body;
+  }
+
+  public async getSessionInfo() {
+    const { body } = await this.client.get<Record<string, unknown>>('/api/v1/session/userinfo');
+    const exp = decodeJwtPayload(this.apiToken)?.exp;
+    return {
+      ...body,
+      tokenExpiresInSeconds: exp !== undefined ? Math.round(exp - Date.now() / 1000) : undefined
+    };
   }
 
   public async createApplication(application: V1alpha1Application) {

--- a/src/argocd/http.ts
+++ b/src/argocd/http.ts
@@ -8,7 +8,7 @@ type SearchParams = Record<string, string | number | boolean | undefined | null>
 
 export class HttpClient {
   public readonly baseUrl: string;
-  public readonly apiToken: string;
+  private apiToken: string;
   public readonly headers: Record<string, string>;
 
   constructor(baseUrl: string, apiToken: string) {
@@ -18,6 +18,11 @@ export class HttpClient {
       Authorization: `Bearer ${this.apiToken}`,
       'Content-Type': 'application/json'
     };
+  }
+
+  public updateToken(newToken: string): void {
+    this.apiToken = newToken;
+    this.headers['Authorization'] = `Bearer ${newToken}`;
   }
 
   private async request<R>(

--- a/src/argocd/jwt.ts
+++ b/src/argocd/jwt.ts
@@ -1,0 +1,18 @@
+export type JwtPayload = {
+  exp?: number;
+  iss?: string;
+  aud?: string | string[];
+  sub?: string;
+  email?: string;
+  groups?: string[];
+};
+
+export const decodeJwtPayload = (token: string): JwtPayload | undefined => {
+  try {
+    const payload = token.split('.')[1];
+    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+    return JSON.parse(Buffer.from(padded, 'base64url').toString('utf8')) as JwtPayload;
+  } catch {
+    return undefined;
+  }
+};

--- a/src/argocd/tokenRefresher.test.ts
+++ b/src/argocd/tokenRefresher.test.ts
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { TokenRefresher, type TokenRefreshResult } from './tokenRefresher.js';
+
+// Build a JWT with a given exp (Unix timestamp). Only the payload matters here.
+const makeToken = (exp: number | undefined): string => {
+  const payload = Buffer.from(JSON.stringify({ exp, iss: 'https://dex.example.com' })).toString(
+    'base64url'
+  );
+  return `header.${payload}.sig`;
+};
+
+const TOKEN_EXPIRES_FAR = makeToken(Math.floor(Date.now() / 1000) + 3600); // 1h from now
+const TOKEN_EXPIRED = makeToken(Math.floor(Date.now() / 1000) - 10); // already expired
+const TOKEN_NO_EXP = makeToken(undefined);
+
+const noopUpdateConfig = () => {};
+
+const makeRefresher = (opts: {
+  performRefresh: (
+    baseUrl: string,
+    currentToken: string,
+    refreshToken: string
+  ) => Promise<TokenRefreshResult>;
+  updateConfig?: (contextName: string, authToken: string, refreshToken?: string) => void;
+}) =>
+  new TokenRefresher({
+    contextName: 'test-ctx',
+    baseUrl: 'https://argocd.example.com',
+    refreshToken: 'initial-rt',
+    performRefresh: opts.performRefresh,
+    updateConfig: opts.updateConfig ?? noopUpdateConfig
+  });
+
+// --- forceRefresh ------------------------------------------------------------
+
+test('forceRefresh calls performRefresh and propagates the new token', async () => {
+  const refresher = makeRefresher({
+    performRefresh: async () => ({ authToken: 'new-token' })
+  });
+
+  let received: string | undefined;
+  refresher.start(TOKEN_EXPIRES_FAR, (t) => {
+    received = t;
+  });
+  refresher.stop(); // cancel scheduled timer so it doesn't interfere
+
+  await refresher.forceRefresh();
+
+  assert.equal(received, 'new-token');
+});
+
+test('forceRefresh rethrows on failure', async () => {
+  const refresher = makeRefresher({
+    performRefresh: async () => {
+      throw new Error('OIDC server down');
+    }
+  });
+
+  refresher.start(TOKEN_EXPIRES_FAR);
+  refresher.stop();
+
+  await assert.rejects(() => refresher.forceRefresh(), /OIDC server down/);
+});
+
+test('forceRefresh updates the stored refresh token when provider returns a new one', async () => {
+  let usedRefreshToken = '';
+  const refresher = makeRefresher({
+    performRefresh: async (_baseUrl, _current, rt) => {
+      usedRefreshToken = rt;
+      return { authToken: 'new-tok', refreshToken: 'rotated-rt' };
+    }
+  });
+
+  refresher.start(TOKEN_EXPIRES_FAR);
+  refresher.stop();
+
+  await refresher.forceRefresh();
+  // Second call should use the rotated token
+  await refresher.forceRefresh();
+
+  assert.equal(usedRefreshToken, 'rotated-rt');
+});
+
+// --- onTokenRefreshed callback -----------------------------------------------
+
+test('onTokenRefreshed is called with the new token on successful forceRefresh', async () => {
+  const received: string[] = [];
+  const refresher = makeRefresher({
+    performRefresh: async () => ({ authToken: 'tok-v2' })
+  });
+
+  refresher.start(TOKEN_EXPIRES_FAR, (t) => received.push(t));
+  refresher.stop();
+
+  await refresher.forceRefresh();
+  assert.deepEqual(received, ['tok-v2']);
+});
+
+test('onTokenRefreshed is NOT called when forceRefresh fails', async () => {
+  const received: string[] = [];
+  const refresher = makeRefresher({
+    performRefresh: async () => {
+      throw new Error('fail');
+    }
+  });
+
+  refresher.start(TOKEN_EXPIRES_FAR, (t) => received.push(t));
+  refresher.stop();
+
+  await assert.rejects(() => refresher.forceRefresh());
+  assert.deepEqual(received, []);
+});
+
+// --- updateConfig persistence -----------------------------------------------
+
+test('updateConfig is called with new auth token on refresh', async () => {
+  const updates: Array<{ contextName: string; authToken: string; refreshToken?: string }> = [];
+
+  const refresher = makeRefresher({
+    performRefresh: async () => ({ authToken: 'new-tok', refreshToken: 'new-rt' }),
+    updateConfig: (ctx, auth, rt) => updates.push({ contextName: ctx, authToken: auth, refreshToken: rt })
+  });
+
+  refresher.start(TOKEN_EXPIRES_FAR);
+  refresher.stop();
+  await refresher.forceRefresh();
+
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].contextName, 'test-ctx');
+  assert.equal(updates[0].authToken, 'new-tok');
+  assert.equal(updates[0].refreshToken, 'new-rt');
+});
+
+// --- scheduling: fallback interval when exp is absent -----------------------
+
+test('stop() cancels a scheduled timer', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  let called = false;
+  const refresher = makeRefresher({
+    performRefresh: async () => {
+      called = true;
+      return { authToken: 'x' };
+    }
+  });
+
+  refresher.start(TOKEN_NO_EXP);
+  refresher.stop();
+  t.mock.timers.tick(60_000);
+
+  assert.equal(called, false);
+});
+
+// --- scheduling: exponential backoff ----------------------------------------
+
+test('doRefresh uses exponential backoff after repeated failures', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  // Token that's already expired -> msUntilRefresh = 0, fires immediately
+  let callCount = 0;
+  const refresher = makeRefresher({
+    performRefresh: async () => {
+      callCount++;
+      throw new Error('fail');
+    }
+  });
+
+  const flushAsync = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+  refresher.start(TOKEN_EXPIRED);
+
+  // First call fires immediately (msUntilRefresh = 0)
+  t.mock.timers.tick(0);
+  await flushAsync();
+  assert.equal(callCount, 1);
+
+  // After 1 failure: backoff = 2^1 * 5000 = 10_000ms
+  t.mock.timers.tick(10_000);
+  await flushAsync();
+  assert.equal(callCount, 2);
+
+  // After 2 failures: backoff = 2^2 * 5000 = 20_000ms
+  t.mock.timers.tick(20_000);
+  await flushAsync();
+  assert.equal(callCount, 3);
+
+  refresher.stop();
+});
+
+test('doRefresh resets failureCount after success so next failure uses 10s backoff not 40s', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  // Fail twice (failureCount -> 2, last backoff = 20s), then succeed, then fail once.
+  // If failureCount resets to 0 after success, the next failure uses backoff = 10s.
+  // If it does NOT reset, the next failure would use backoff = 40s (2^3 * 5s),
+  // and tick(10_000) below would not fire.
+  let callCount = 0;
+  let failsLeft = 2;
+
+  const refresher = makeRefresher({
+    performRefresh: async () => {
+      callCount++;
+      if (failsLeft > 0) {
+        failsLeft--;
+        throw new Error('fail');
+      }
+      // Return an already-expired token so scheduleNext fires at delay=0
+      return { authToken: TOKEN_EXPIRED };
+    }
+  });
+
+  const flushAsync = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+  refresher.start(TOKEN_EXPIRED);
+
+  // Call 1: fail -> failureCount=1, backoff=10s
+  t.mock.timers.tick(0);
+  await flushAsync();
+  assert.equal(callCount, 1);
+
+  // Call 2: fail -> failureCount=2, backoff=20s
+  t.mock.timers.tick(10_000);
+  await flushAsync();
+  assert.equal(callCount, 2);
+
+  // Call 3: succeed -> failureCount resets to 0, scheduleNext(TOKEN_EXPIRED) -> 0ms timer
+  t.mock.timers.tick(20_000);
+  await flushAsync();
+  assert.equal(callCount, 3);
+
+  // Call 4: fail again — failureCount should be 1 (reset), backoff = 10s
+  failsLeft = 1;
+  t.mock.timers.tick(0); // fire the 0ms timer set by scheduleNext after success
+  await flushAsync();
+  assert.equal(callCount, 4);
+
+  // tick(10s): if failureCount reset -> fires; if not reset -> would need 40s -> would NOT fire
+  t.mock.timers.tick(10_000);
+  await flushAsync();
+  assert.equal(callCount, 5);
+
+  refresher.stop();
+});

--- a/src/argocd/tokenRefresher.ts
+++ b/src/argocd/tokenRefresher.ts
@@ -1,0 +1,230 @@
+import { logger } from '../logging/logging.js';
+import { updateTokensInConfig } from './argocdConfig.js';
+import { decodeJwtPayload } from './jwt.js';
+export type { JwtPayload } from './jwt.js';
+
+// Refresh the token this many seconds before it expires
+const REFRESH_BEFORE_EXPIRY_SECS = 300;
+// How often to check token validity when expiry cannot be determined
+const FALLBACK_CHECK_INTERVAL_MS = 60_000;
+
+type TokenRefresherOptions = {
+  contextName: string;
+  baseUrl: string;
+  refreshToken: string;
+  // Injected for testing; defaults to the module-level performTokenRefresh
+  performRefresh?: (
+    baseUrl: string,
+    currentToken: string,
+    refreshToken: string
+  ) => Promise<TokenRefreshResult>;
+  // Injected for testing; defaults to updateTokensInConfig
+  updateConfig?: (contextName: string, authToken: string, refreshToken?: string) => void;
+};
+
+const secondsUntilExpiry = (token: string): number | undefined => {
+  const exp = decodeJwtPayload(token)?.exp;
+  return exp !== undefined ? exp - Date.now() / 1000 : undefined;
+};
+
+type OidcParams = { tokenEndpoint: string; clientId: string };
+
+// Discover the token endpoint and client_id for the token refresh request.
+//
+// Strategy (matches ArgoCD CLI behaviour):
+// 1. Use the JWT `iss` claim as the OIDC issuer and fetch its discovery document.
+//    This covers Azure AD, Okta, and any other external OIDC provider.
+// 2. Fall back to the ArgoCD server's own discovery document (covers built-in Dex).
+// 3. If neither is reachable, fall back to the Dex default endpoint.
+//
+// The `client_id` is taken from the JWT `aud` claim when available, because
+// that is the client registered with the OIDC provider (e.g. the Azure AD app ID).
+// For Dex the `aud` is typically `argo-cd-cli`, which is also the right value.
+const resolveOidcParams = async (
+  baseUrl: string,
+  jwtPayload: ReturnType<typeof decodeJwtPayload>
+): Promise<OidcParams> => {
+  const dexDefault = `${baseUrl}/api/dex/token`;
+  const dexClientId = 'argo-cd-cli';
+
+  const aud = jwtPayload?.aud;
+  // For multi-audience tokens aud[0] is a best-effort guess — Azure AD may put
+  // the resource audience before the client ID. Use --client-id to override if needed.
+  const clientId = Array.isArray(aud) ? aud[0] : (aud ?? dexClientId);
+
+  const tryDiscovery = async (issuerUrl: string): Promise<string | undefined> => {
+    try {
+      const url = `${issuerUrl.replace(/\/$/, '')}/.well-known/openid-configuration`;
+      const response = await fetch(url);
+      if (response.ok) {
+        const data = (await response.json()) as { token_endpoint?: string };
+        return data.token_endpoint;
+      }
+    } catch {
+      // fall through
+    }
+    return undefined;
+  };
+
+  // 1. Issuer from the JWT itself (Azure AD, Okta, external OIDC)
+  if (jwtPayload?.iss) {
+    const endpoint = await tryDiscovery(jwtPayload.iss);
+    if (endpoint) return { tokenEndpoint: endpoint, clientId };
+  }
+
+  // 2. ArgoCD server's discovery document (Dex proxied through ArgoCD)
+  const endpoint = await tryDiscovery(baseUrl);
+  if (endpoint) return { tokenEndpoint: endpoint, clientId };
+
+  // 3. Hardcoded Dex path
+  return { tokenEndpoint: dexDefault, clientId: dexClientId };
+};
+
+export type TokenRefreshResult = {
+  authToken: string;
+  refreshToken?: string;
+};
+
+// Perform a one-shot OIDC refresh_token grant and return the new tokens.
+// The caller is responsible for persisting and propagating the result.
+export const performTokenRefresh = async (
+  baseUrl: string,
+  currentToken: string,
+  refreshToken: string
+): Promise<TokenRefreshResult> => {
+  const jwtPayload = decodeJwtPayload(currentToken);
+  const { tokenEndpoint, clientId } = await resolveOidcParams(baseUrl, jwtPayload);
+
+  const response = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: clientId
+    }).toString()
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`HTTP ${response.status}: ${text.slice(0, 200)}`);
+  }
+
+  const result = (await response.json()) as {
+    id_token?: string;
+    access_token?: string;
+    refresh_token?: string;
+  };
+  // Prefer id_token (contains ArgoCD groups/roles) over access_token
+  const authToken = result.id_token ?? result.access_token;
+  if (!authToken) {
+    throw new Error('Token refresh response did not contain a new token');
+  }
+
+  return { authToken, refreshToken: result.refresh_token };
+};
+
+export class TokenRefresher {
+  private readonly contextName: string;
+  private readonly baseUrl: string;
+  private refreshToken: string;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private currentToken: string | undefined;
+  private onTokenRefreshed: ((newToken: string) => void) | undefined;
+  private failureCount = 0;
+  private static readonly MAX_BACKOFF_MS = 10 * 60 * 1000;
+  private readonly performRefreshFn: NonNullable<TokenRefresherOptions['performRefresh']>;
+  private readonly updateConfigFn: NonNullable<TokenRefresherOptions['updateConfig']>;
+
+  constructor(options: TokenRefresherOptions) {
+    this.contextName = options.contextName;
+    this.baseUrl = options.baseUrl;
+    this.refreshToken = options.refreshToken;
+    this.performRefreshFn = options.performRefresh ?? performTokenRefresh;
+    this.updateConfigFn = options.updateConfig ?? updateTokensInConfig;
+  }
+
+  public start(currentToken: string, onTokenRefreshed?: (newToken: string) => void): void {
+    this.currentToken = currentToken;
+    this.onTokenRefreshed = onTokenRefreshed;
+    this.scheduleNext();
+  }
+
+  public stop(): void {
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  // Immediately perform a token refresh, cancelling any pending scheduled refresh.
+  // Reschedules the next automatic refresh on completion (success or failure).
+  // Throws on refresh failure so the caller can surface the error.
+  public async forceRefresh(): Promise<void> {
+    this.stop();
+    logger.info(`Force-refreshing ArgoCD token for context "${this.contextName}"`);
+    try {
+      await this.executeRefresh();
+      logger.info(`Token force-refreshed successfully for context "${this.contextName}"`);
+    } finally {
+      this.scheduleNext();
+    }
+  }
+
+  private scheduleNext(): void {
+    const token = this.currentToken;
+    if (!token) return;
+
+    const secsLeft = secondsUntilExpiry(token);
+    if (secsLeft === undefined) {
+      // Cannot determine expiry — retry after fallback interval
+      this.timer = setTimeout(() => this.scheduleNext(), FALLBACK_CHECK_INTERVAL_MS).unref();
+      return;
+    }
+
+    const msUntilRefresh = Math.max(0, (secsLeft - REFRESH_BEFORE_EXPIRY_SECS) * 1000);
+    logger.info(
+      `Token refresh scheduled in ${Math.round(msUntilRefresh / 1000)}s ` +
+        `(expires in ${Math.round(secsLeft)}s)`
+    );
+    this.timer = setTimeout(() => void this.doRefresh(), msUntilRefresh).unref();
+  }
+
+  private async doRefresh(): Promise<void> {
+    logger.info(`Refreshing ArgoCD token for context "${this.contextName}"`);
+    try {
+      await this.executeRefresh();
+      this.failureCount = 0;
+      logger.info(`Token refreshed successfully for context "${this.contextName}"`);
+    } catch (err) {
+      this.failureCount++;
+      const backoffMs = Math.min(
+        Math.pow(2, this.failureCount) * 5_000,
+        TokenRefresher.MAX_BACKOFF_MS
+      );
+      logger.error(
+        `Token refresh failed for context "${this.contextName}": ${err instanceof Error ? err.message : String(err)}`
+      );
+      logger.info(
+        `Will retry in ${Math.round(backoffMs / 1000)}s (attempt ${this.failureCount})`
+      );
+      this.timer = setTimeout(() => void this.doRefresh(), backoffMs).unref();
+      return;
+    }
+    this.scheduleNext();
+  }
+
+  private async executeRefresh(): Promise<void> {
+    const result = await this.performRefreshFn(
+      this.baseUrl,
+      this.currentToken ?? '',
+      this.refreshToken
+    );
+    if (result.refreshToken) {
+      this.refreshToken = result.refreshToken;
+    }
+    this.currentToken = result.authToken;
+    this.updateConfigFn(this.contextName, result.authToken, result.refreshToken);
+    this.onTokenRefreshed?.(result.authToken);
+  }
+}

--- a/src/cmd/cmd.ts
+++ b/src/cmd/cmd.ts
@@ -8,6 +8,8 @@ import {
 } from '../server/transport.js';
 import { DEFAULT_BIND_ADDRESS } from '../server/security.js';
 import { logger } from '../logging/logging.js';
+import { getContextInfo, type ArgocdContextInfo } from '../argocd/argocdConfig.js';
+import { TokenRefresher } from '../argocd/tokenRefresher.js';
 
 // Options shared by the two network transports. The inbound token is env-only:
 // argv is readable by every user on the machine via `ps`.
@@ -96,8 +98,40 @@ export const cmd = () => {
   exe.command(
     'stdio',
     'Start ArgoCD MCP server using stdio.',
-    () => {},
-    () => connectStdioTransport()
+    (yargs) =>
+      yargs.option('context', {
+        type: 'string',
+        description:
+          'ArgoCD CLI context name from ~/.config/argocd/config. ' +
+          'When set, credentials and base URL are read from that context and the ' +
+          'token is refreshed automatically before it expires.'
+      }),
+    (argv) => {
+      if (!argv.context) {
+        connectStdioTransport();
+        return;
+      }
+
+      let ctxInfo: ArgocdContextInfo;
+      try {
+        ctxInfo = getContextInfo(argv.context);
+      } catch (err) {
+        logger.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+
+      connectStdioTransport({
+        argocdBaseUrl: ctxInfo.baseUrl,
+        argocdApiToken: ctxInfo.authToken,
+        tokenRefresher: ctxInfo.refreshToken
+          ? new TokenRefresher({
+              contextName: argv.context,
+              baseUrl: ctxInfo.baseUrl,
+              refreshToken: ctxInfo.refreshToken
+            })
+          : undefined
+      });
+    }
   );
 
   exe.command('sse', 'Start ArgoCD MCP server using SSE.', listenerOptions, (argv) =>

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { createServer } from './server.js';
 import { TokenRegistry } from './tokenRegistry.js';
+import { TokenRefresher } from '../argocd/tokenRefresher.js';
 
 // These tests exercise the per-call token-resolution boundary in resolveClient
 // via the registered tool handlers. The security-critical invariant is:
@@ -174,4 +175,109 @@ test('with no default token, an overridden URL still resolves only from the regi
   const result = await callTool(server, 'list_applications', { argocdBaseUrl: EVIL_BASE_URL });
   assert.equal(result.isError, true);
   assert.match(textOf(result), /Missing required ArgoCD API token/);
+});
+
+// --- get_session_info --------------------------------------------------------
+
+test('get_session_info fails with missing base URL error when server has no default URL', async () => {
+  const server = createServer({
+    argocdBaseUrl: '',
+    argocdApiToken: '',
+    tokenRegistry: new TokenRegistry([{ baseUrl: DEFAULT_BASE_URL, token: DEFAULT_TOKEN }])
+  });
+
+  const result = await callTool(server, 'get_session_info', {});
+  assert.equal(result.isError, true);
+  assert.match(textOf(result), /Missing required ArgoCD base URL/);
+});
+
+// --- refresh_token tool ------------------------------------------------------
+
+test('refresh_token tool is NOT registered when server has no tokenRefresher', () => {
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry()
+  });
+
+  const registered = (
+    server as unknown as { _registeredTools: Record<string, unknown> }
+  )._registeredTools;
+
+  assert.ok(!('refresh_token' in registered), 'refresh_token should not be registered');
+});
+
+test('refresh_token tool IS registered when server has a tokenRefresher', () => {
+  const refresher = new TokenRefresher({
+    contextName: 'test',
+    baseUrl: DEFAULT_BASE_URL,
+    refreshToken: 'rt',
+    performRefresh: async () => ({ authToken: 'x' }),
+    updateConfig: () => {}
+  });
+
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry(),
+    tokenRefresher: refresher
+  });
+
+  const registered = (
+    server as unknown as { _registeredTools: Record<string, unknown> }
+  )._registeredTools;
+
+  assert.ok('refresh_token' in registered, 'refresh_token should be registered');
+});
+
+test('refresh_token tool returns isError:true when refresh fails', async () => {
+  const refresher = new TokenRefresher({
+    contextName: 'test',
+    baseUrl: DEFAULT_BASE_URL,
+    refreshToken: 'rt',
+    performRefresh: async () => {
+      throw new Error('OIDC unavailable');
+    },
+    updateConfig: () => {}
+  });
+
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry(),
+    tokenRefresher: refresher
+  });
+
+  // Start without a callback so no side-effects; stop immediately to avoid timer leaks
+  refresher.start('');
+  refresher.stop();
+
+  const result = await callTool(server, 'refresh_token', {});
+  assert.equal(result.isError, true);
+  assert.match(textOf(result), /OIDC unavailable/);
+});
+
+test('refresh_token tool returns success when refresh succeeds', async () => {
+  const refresher = new TokenRefresher({
+    contextName: 'test',
+    baseUrl: DEFAULT_BASE_URL,
+    refreshToken: 'rt',
+    performRefresh: async () => ({ authToken: 'new-tok' }),
+    updateConfig: () => {}
+  });
+
+  const server = createServer({
+    argocdBaseUrl: DEFAULT_BASE_URL,
+    argocdApiToken: DEFAULT_TOKEN,
+    tokenRegistry: new TokenRegistry(),
+    tokenRefresher: refresher
+  });
+
+  refresher.start('header.e30.sig'); // minimal valid JWT (empty payload)
+  refresher.stop();
+
+  const result = await callTool(server, 'refresh_token', {});
+  assert.equal(result.isError, false);
+  const body = JSON.parse(textOf(result));
+  assert.equal(body.success, true);
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10,6 +10,7 @@ import {
   ResourceRefSchema
 } from '../shared/models/schema.js';
 import { TokenRegistry, tokenRegistryFromEnv } from './tokenRegistry.js';
+import { TokenRefresher } from '../argocd/tokenRefresher.js';
 
 type ServerInfo = {
   argocdBaseUrl: string;
@@ -17,6 +18,9 @@ type ServerInfo = {
   // Optional registry mapping additional ArgoCD base URLs to their tokens. When
   // omitted, it is loaded from the ARGOCD_TOKEN_REGISTRY_PATH env var.
   tokenRegistry?: TokenRegistry;
+  // Optional background token refresher. When present, enables the
+  // refresh_token tool that forces an immediate token refresh.
+  tokenRefresher?: TokenRefresher;
 };
 
 // Per-call argument that any tool may accept to target a specific ArgoCD
@@ -45,6 +49,7 @@ export class Server extends McpServer {
   private defaultApiToken: string;
   private tokenRegistry: TokenRegistry;
   private argocdClient: ArgoCDClient;
+  private tokenRefresher: TokenRefresher | undefined;
   // Cache per-credential clients to avoid rebuilding the HttpClient on every
   // call. Keyed by baseUrl + token, since the same base URL may resolve to
   // different tokens (request token vs. registry token vs. default).
@@ -59,6 +64,7 @@ export class Server extends McpServer {
     this.defaultApiToken = serverInfo.argocdApiToken;
     this.tokenRegistry = serverInfo.tokenRegistry ?? tokenRegistryFromEnv();
     this.argocdClient = new ArgoCDClient(serverInfo.argocdBaseUrl, serverInfo.argocdApiToken);
+    this.tokenRefresher = serverInfo.tokenRefresher;
 
     const isReadOnly =
       String(process.env.MCP_READ_ONLY ?? '')
@@ -274,6 +280,48 @@ export class Server extends McpServer {
         )
     );
 
+    // Session / token tools — always available, read-only by nature
+    this.addJsonOutputTool(
+      'get_session_info',
+      'get_session_info returns the current ArgoCD session info: logged-in user, groups, ' +
+        'and the number of seconds until the authentication token expires.',
+      {},
+      async (_args, client) => await client.getSessionInfo()
+    );
+
+    // refresh_token is a credential-management tool, not a data write operation,
+    // so it is available regardless of MCP_READ_ONLY. Only registered when a
+    // TokenRefresher is present (i.e. server started with --context).
+    if (this.tokenRefresher) {
+      const refresher = this.tokenRefresher;
+      this.tool(
+        'refresh_token',
+        'refresh_token immediately refreshes the ArgoCD authentication token using the ' +
+          'stored refresh token. Only available when the server is started with --context. ' +
+          'Use this when the current token has expired or is about to expire.',
+        {},
+        async () => {
+          try {
+            await refresher.forceRefresh();
+            return {
+              isError: false,
+              content: [{ type: 'text' as const, text: JSON.stringify({ success: true }) }]
+            };
+          } catch (error) {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: 'text' as const,
+                  text: error instanceof Error ? error.message : String(error)
+                }
+              ]
+            };
+          }
+        }
+      );
+    }
+
     // Only register modification tools if not in read-only mode
     if (!isReadOnly) {
       this.addJsonOutputTool(
@@ -380,7 +428,18 @@ export class Server extends McpServer {
             action
           )
       );
+
     }
+  }
+
+  // Update the default token and propagate it to the cached default client.
+  // Called by TokenRefresher when a background refresh succeeds.
+  public updateToken(newToken: string): void {
+    this.defaultApiToken = newToken;
+    this.argocdClient.updateToken(newToken);
+    // Clear the client cache so subsequent calls with the default URL pick up
+    // the new token rather than an entry keyed on the old one.
+    this.clientCache.clear();
   }
 
   // Resolve the ArgoCD client to use for a single tool call. The base URL may be

--- a/src/server/transport.ts
+++ b/src/server/transport.ts
@@ -4,6 +4,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { logger } from '../logging/logging.js';
 import { createServer } from './server.js';
 import { randomUUID } from 'node:crypto';
+import { TokenRefresher } from '../argocd/tokenRefresher.js';
 import type { AddressInfo } from 'node:net';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
@@ -19,15 +20,30 @@ import {
 // construction.
 const tokenRegistry = tokenRegistryFromEnv();
 
-export const connectStdioTransport = () => {
+export type StdioOptions = {
+  argocdBaseUrl?: string;
+  argocdApiToken?: string;
+  tokenRefresher?: TokenRefresher;
+};
+
+export const connectStdioTransport = (options: StdioOptions = {}) => {
+  const argocdBaseUrl = options.argocdBaseUrl ?? process.env.ARGOCD_BASE_URL ?? '';
+  const argocdApiToken = options.argocdApiToken ?? process.env.ARGOCD_API_TOKEN ?? '';
+
   const server = createServer({
-    argocdBaseUrl: process.env.ARGOCD_BASE_URL || '',
-    argocdApiToken: process.env.ARGOCD_API_TOKEN || '',
-    tokenRegistry
+    argocdBaseUrl,
+    argocdApiToken,
+    tokenRegistry,
+    tokenRefresher: options.tokenRefresher
   });
+
+  if (options.tokenRefresher) {
+    options.tokenRefresher.start(argocdApiToken, (newToken) => server.updateToken(newToken));
+  }
 
   logger.info('Connecting to stdio transport');
   server.connect(new StdioServerTransport());
+  return server;
 };
 
 export type TransportOptions = ListenerSecurityOptions;


### PR DESCRIPTION
## Summary

- Adds `--context <name>` flag to the `stdio` command that reads credentials
  and base URL from the local ArgoCD CLI config (`~/.config/argocd/config`
  or `$ARGOCD_CONFIG_HOME/config`) — backward compatible, without the flag
  behaviour is unchanged
- Automatically refreshes the OIDC token before expiry using a three-tier
  discovery strategy (JWT issuer -> ArgoCD server -> Dex fallback), covering
  Azure AD, Okta, and built-in Dex
- Two new MCP tools: `get_session_info` (current user, groups, token TTL)
  and `refresh_token` (force immediate refresh, only available with `--context`)

## Reliability

- Exponential backoff (up to 10 min) on repeated refresh failures — prevents
  tight retry loops against the OIDC server
- Config file writes are atomic (write-to-temp + rename)
- Refresh timers are unref'd so the process exits cleanly on stdio disconnect

## Test plan

- [x] 27 new tests: argocd config parsing/errors/atomic write,
  `TokenRefresher` backoff/reset/callbacks (via `mock.timers`),
  `refresh_token` tool registration and error/success paths
- [x] `npm test` — 92/92 pass
- [x] `npm run build` — clean